### PR TITLE
Add GitHub Actions workflows for PyPI publishing

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,0 +1,40 @@
+name: PyPI Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write  # Required for trusted publishing
+  contents: read
+
+jobs:
+  pypi-publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    if: github.event.release.prerelease == false  # Only run for full releases
+    environment:
+      name: pypi
+      url: https://pypi.org/project/django-manifeststaticfiles-enhanced/
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+    
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build
+    
+    - name: Build package
+      run: python -m build
+    
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        verbose: true

--- a/.github/workflows/test-pypi-release.yml
+++ b/.github/workflows/test-pypi-release.yml
@@ -1,0 +1,42 @@
+name: Test PyPI Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:  # Allow manual triggering for testing
+
+permissions:
+  id-token: write  # Required for trusted publishing
+  contents: read
+
+jobs:
+  test-pypi-publish:
+    name: Publish to Test PyPI
+    runs-on: ubuntu-latest
+    if: github.event.release.prerelease == true  # Only run for pre-releases
+    environment:
+      name: test-pypi
+      url: https://test.pypi.org/project/django-manifeststaticfiles-enhanced/
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+    
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build
+    
+    - name: Build package
+      run: python -m build
+    
+    - name: Publish to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        verbose: true


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for publishing to PyPI using trusted publishing
- Add separate workflow for testing releases on TestPyPI
- Configure workflows to trigger on GitHub releases only
- Set up proper permissions and environment separation

## Key Features
- **Security**: Uses PyPI trusted publishing (no API tokens needed)
- **Testing**: TestPyPI workflow runs for pre-releases
- **Production**: PyPI workflow runs for full releases only
- **Manual testing**: TestPyPI workflow can be triggered manually

## Test plan
- [ ] Set up trusted publishing on TestPyPI
- [ ] Create a pre-release to test TestPyPI workflow
- [ ] Verify package publishes correctly to TestPyPI
- [ ] Set up trusted publishing on production PyPI
- [ ] Create a full release to test production workflow

🤖 Generated with [Claude Code](https://claude.ai/code)