### PR TITLE
Tidy up build practices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,16 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
         django-version: ["4.2", "5.0", "5.1", "5.2"]
         exclude:
           # Django 5.0+ requires Python 3.10+
-          - python-version: 3.8
-            django-version: "5.0"
-          - python-version: 3.8
-            django-version: "5.1"
-          - python-version: 3.8
-            django-version: "5.2"
           - python-version: 3.9
             django-version: "5.0"
           - python-version: 3.9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,4 +75,4 @@ jobs:
 
     - name: Run tests
       run: |
-        python runtests.py
+        python tests/runtests.py

--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ keep_original_files = False
 pip install -e .[dev]
 
 # Run tests
-python runtests.py
+python tests/runtests.py
 
 # Or run specific test modules
-python runtests.py tests.staticfiles_tests.test_storage
+python tests/runtests.py staticfiles_tests.test_storage
 ```
 
 ## Migration from Django's ManifestStaticFilesStorage

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This package includes several improvements to Django's `ManifestStaticFilesStora
 ## Compatibility
 
 - **Django**: 4.2, 5.0, 5.1, 5.2
-- **Python**: 3.8, 3.9, 3.10, 3.11, 3.12, 3.13
+- **Python**: 3.9, 3.10, 3.11, 3.12, 3.13
 
 ## Installation
 

--- a/django_manifeststaticfiles_enhanced/__init__.py
+++ b/django_manifeststaticfiles_enhanced/__init__.py
@@ -5,7 +5,7 @@ Enhanced ManifestStaticFilesStorage for Django with improvements from
 Django tickets: 27929, 21080, 26583, 28200, 34322
 """
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 from .storage import EnhancedManifestStaticFilesStorage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [build-system]
-requires = ["setuptools>=45", "wheel"]
+requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-manifeststaticfiles-enhanced"
-version = "0.1.2"
+version = "0.1.3"
 description = "Enhanced ManifestStaticFilesStorage for Django"
 readme = "README.md"
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
 authors = [
     {name = "Django ManifestStaticFiles Enhanced Contributors"}
 ]
@@ -21,7 +21,6 @@ classifiers = [
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
@@ -51,10 +50,6 @@ dev = [
 Homepage = "https://github.com/blighj/django-manifeststaticfiles-enhanced"
 Repository = "https://github.com/blighj/django-manifeststaticfiles-enhanced"
 Issues = "https://github.com/blighj/django-manifeststaticfiles-enhanced/issues"
-
-[tool.setuptools.packages.find]
-where = ["."]
-include = ["django_manifeststaticfiles_enhanced*"]
 
 [tool.black]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -34,7 +33,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "Django>=4.2",
 ]

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -14,12 +14,7 @@ from django.test.utils import get_runner
 
 def setup_test_environment():
     """Setup Django test environment"""
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.staticfiles_tests.settings")
-
-    # Add the tests directory to sys.path so imports work without 'tests.' prefix
-    tests_path = os.path.join(os.path.dirname(__file__), "tests")
-    if tests_path not in sys.path:
-        sys.path.insert(0, tests_path)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "staticfiles_tests.settings")
 
     django.setup()
 
@@ -31,13 +26,10 @@ def run_tests(test_path=None):
     test_runner = TestRunner(verbosity=2, interactive=True)
 
     if test_path:
-        # Convert path format to Django test format
-        if not test_path.startswith("tests."):
-            test_path = f"tests.staticfiles_tests.{test_path}"
         test_labels = [test_path]
     else:
         # Run all tests if no specific path provided
-        test_labels = ["tests.staticfiles_tests"]
+        test_labels = ["staticfiles_tests"]
 
     failures = test_runner.run_tests(test_labels)
     if failures:


### PR DESCRIPTION
After a helpful eye by django discord channel, noticed some things that can be improved.
- Removing unneeded lines in toml file, setuptools can auto-discover the package.
- Setuptools was set to minimum 45 which was when it dropped python2 support, moved that up to 61 at a minimum when, I probably could remove the minimum alltogether, but I copied it from somewhere so more comfortable leaving it in my ignorant state.
- Specifiy license in [SPDX](https://packaging.python.org/en/latest/glossary/#term-License-Expression) format
- Move runtests.py to the tests folder
- Remove python 3.8 support