### PR TITLE
Fixed issue with template literals

### DIFF
--- a/django_manifeststaticfiles_enhanced/jslex.py
+++ b/django_manifeststaticfiles_enhanced/jslex.py
@@ -454,7 +454,14 @@ def find_import_export_strings(file_contents):
     def _append_match(token_tuple):
         # we can't support template strings with variables
         if token_tuple[1].startswith("`") and "${" in token_tuple[1]:
-            return
+            url = token_tuple[1]
+            message = (
+                f"Found a template literale with a variable: {url} "
+                "Dynamic imports with template literals containing variables "
+                "are not supported as the actual import path cannot be "
+                "determined at build time."
+            )
+            raise ValueError(message)
 
         # the lex parser returns the string, with the wrapping quotes, remove them
         matches.append((token_tuple[1][1:-1], token_tuple[2] + 1))

--- a/django_manifeststaticfiles_enhanced/jslex.py
+++ b/django_manifeststaticfiles_enhanced/jslex.py
@@ -452,6 +452,10 @@ def find_import_export_strings(file_contents):
     matches = []
 
     def _append_match(token_tuple):
+        # we can't support template strings with variables
+        if token_tuple[1].startswith("`") and "${" in token_tuple[1]:
+            return
+
         # the lex parser returns the string, with the wrapping quotes, remove them
         matches.append((token_tuple[1][1:-1], token_tuple[2] + 1))
 

--- a/django_manifeststaticfiles_enhanced/storage.py
+++ b/django_manifeststaticfiles_enhanced/storage.py
@@ -189,11 +189,18 @@ class EnhancedHashedFilesMixin(HashedFilesMixin):
                 if self.support_js_module_import_aggregation and matches_patterns(
                     path, ("*.js",)
                 ):
-                    for url_name, position in find_import_export_strings(content):
-                        if self._should_adjust_url(url_name):
-                            target = self._get_target_name(url_name, name)
-                            dependencies.add(target)
-                            url_positions.append((url_name, position))
+                    try:
+                        for url_name, position in find_import_export_strings(content):
+                            if self._should_adjust_url(url_name):
+                                target = self._get_target_name(url_name, name)
+                                dependencies.add(target)
+                                url_positions.append((url_name, position))
+                    except ValueError as e:
+                        message = e.args[0] if len(e.args) else ""
+                        message = (
+                            f"The js file '{name}' could not be processed.\n{message}"
+                        )
+                        raise ValueError(message)
 
                 # Check for sourceMappingURL
                 if "sourceMappingURL" in content:

--- a/tests/staticfiles_tests/project/documents/cached/module.js
+++ b/tests/staticfiles_tests/project/documents/cached/module.js
@@ -49,8 +49,3 @@ r = /import/;
  * @param {HTMLElement} elt
  * @returns {import("./htmx").HtmxTriggerSpecification[]}
  */
-
-//Technically valid but not supported as it should be a real edge case
-`${import("./module_test.js")}`
-//Technically valid but not supported as no way to know what path of module_name is
-import(`./${module_name}`);

--- a/tests/staticfiles_tests/project/documents/cached/module.js
+++ b/tests/staticfiles_tests/project/documents/cached/module.js
@@ -17,6 +17,8 @@ import relativeModule from "../nested/js/nested.js";
 
 // Dynamic imports.
 const dynamicModule = import("./module_test.js");
+const dynamicModule = import('./module_test.js');
+const dynamicModule = import(`./module_test.js`);
 
 // import with assert
 import k from"./other.css"assert{type:"css"};
@@ -50,3 +52,5 @@ r = /import/;
 
 //Technically valid but not supported as it should be a real edge case
 `${import("./module_test.js")}`
+//Technically valid but not supported as no way to know what path of module_name is
+import(`./${module_name}`);

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -818,7 +818,7 @@ class TestCollectionJSModuleImportAggregationManifestStorage(CollectionTestCase)
 
     def test_module_import(self):
         relpath = self.hashed_file_path("cached/module.js")
-        self.assertEqual(relpath, "cached/module.76a513096c36.js")
+        self.assertEqual(relpath, "cached/module.be91c11e5fd6.js")
         tests = [
             # Relative imports.
             b'import testConst from "./module_test.477bbebe77f0.js";',
@@ -828,6 +828,8 @@ class TestCollectionJSModuleImportAggregationManifestStorage(CollectionTestCase)
             b'import rootConst from "/static/absolute_root.5586327fe78c.js";',
             # Dynamic import.
             b'const dynamicModule = import("./module_test.477bbebe77f0.js");',
+            b"const dynamicModule = import('./module_test.477bbebe77f0.js');",
+            b"const dynamicModule = import(`./module_test.477bbebe77f0.js`);",
             # Creating a module object.
             b'import * as NewModule from "./module_test.477bbebe77f0.js";',
             # Creating a minified module object.
@@ -855,6 +857,7 @@ class TestCollectionJSModuleImportAggregationManifestStorage(CollectionTestCase)
             b" * @param {HTMLElement} elt\n"
             b' * @returns {import("./htmx").HtmxTriggerSpecification[]}\n'
             b" */",
+            b"import(`./${module_name}`);",
         ]
         with storage.staticfiles_storage.open(relpath) as relfile:
             content = relfile.read()
@@ -864,7 +867,7 @@ class TestCollectionJSModuleImportAggregationManifestStorage(CollectionTestCase)
 
     def test_aggregating_modules(self):
         relpath = self.hashed_file_path("cached/module.js")
-        self.assertEqual(relpath, "cached/module.76a513096c36.js")
+        self.assertEqual(relpath, "cached/module.be91c11e5fd6.js")
         tests = [
             b'export * from "./module_test.477bbebe77f0.js";',
             b'export { testConst } from "./module_test.477bbebe77f0.js";',


### PR DESCRIPTION
If a javascript library is using some syntax similar to the below we do not want to try and replace the string.
```js
import(`./${module_name}`);
```
