### PR TITLE
Fix minor issues with js imports

### DIFF
--- a/django_manifeststaticfiles_enhanced/__init__.py
+++ b/django_manifeststaticfiles_enhanced/__init__.py
@@ -5,7 +5,7 @@ Enhanced ManifestStaticFilesStorage for Django with improvements from
 Django tickets: 27929, 21080, 26583, 28200, 34322
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 from .storage import EnhancedManifestStaticFilesStorage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-manifeststaticfiles-enhanced"
-version = "0.2.0"
+version = "0.2.1"
 description = "Enhanced ManifestStaticFilesStorage for Django"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
The code was not handling import when used as a method, discovered when processing [quill.js](https://github.com/slab/quill/blob/ebe16ca24724ac4f52505628ac2c4934f0a98b85/packages/quill/src/core/quill.ts#L117), it also wasn't supporting syntax suggested by [mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) to reload modules ```import(`/my-module.js?t=${Date.now()}`);```
