### PR TITLE
Add an ignore_errors option

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ STORAGES = {
 ```
 
 Also available:
- - [max_post_process_passes](https://docs.djangoproject.com/en/5.2/ref/contrib/staticfiles/#django.contrib.staticfiles.storage.ManifestStaticFilesStorage.max_post_process_passes)
  - manifest_name: change the name of the staticfiles.json file
 
 ## Feature Details
@@ -154,6 +153,29 @@ keep_original_files = False
 # Results in: style.abc123.css only
 ```
 
+### Ignoring specific errors
+
+Ignore specific errors during post-processing with the `ignore_errors` option. This is useful when you have third-party libraries that reference non-existent files or use dynamic path construction that can't be properly parsed.
+
+```python
+# settings.py
+STORAGES = {
+    "staticfiles": {
+        "BACKEND": "django_manifeststaticfiles_enhanced.storage.EnhancedManifestStaticFilesStorage",
+        "OPTIONS": {
+            "ignore_errors": [
+                # Format: "file_pattern:missing_url_pattern"
+                "vendor/bootstrap/*.css:missing-font.woff",  # Ignore missing font in bootstrap CSS
+                "vendor/es/*.js:*",  # Ignore all missing missing references in vendors ES version
+                "*/*.css:../img/background.png"  # Ignore specific missing image in all CSS files
+            ],
+        },
+    },
+}
+```
+
+Patterns support wildcard matching with `*` to match any number of characters.
+
 ## Running Tests
 
 ```bash
@@ -186,6 +208,11 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 This project is licensed under the BSD 3-Clause License - the same license as Django.
 
 ## Changelog
+
+### 0.3.0
+
+- Added `ignore_errors` option to allow ignoring specific file reference errors during post-processing
+- Improved error handling to continue processing when errors are explicitly ignored
 
 ### 0.2.0
 

--- a/django_manifeststaticfiles_enhanced/__init__.py
+++ b/django_manifeststaticfiles_enhanced/__init__.py
@@ -5,7 +5,7 @@ Enhanced ManifestStaticFilesStorage for Django with improvements from
 Django tickets: 27929, 21080, 26583, 28200, 34322
 """
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 from .storage import EnhancedManifestStaticFilesStorage
 

--- a/django_manifeststaticfiles_enhanced/jslex.py
+++ b/django_manifeststaticfiles_enhanced/jslex.py
@@ -443,7 +443,7 @@ def extract_css_urls(css_content):
     return urls
 
 
-def find_import_export_strings(file_contents):
+def find_import_export_strings(file_contents, should_ignore_url=None):
     lexer = JsLexer()
     tokens = list(lexer.lex(file_contents))
     # remove all whitespace
@@ -455,7 +455,8 @@ def find_import_export_strings(file_contents):
         if token_tuple[1].startswith("`") and "${" in token_tuple[1]:
             url = token_tuple[1][1:-1].split("?")[0]
             if "${" in url:
-                print(url)
+                if should_ignore_url(url):
+                    return
                 message = (
                     f"Found a template literal with a variable: {url} "
                     "Dynamic imports with template literals containing variables "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-manifeststaticfiles-enhanced"
-version = "0.2.1"
+version = "0.3.0"
 description = "Enhanced ManifestStaticFilesStorage for Django"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
This adds the ability to add an "ignore_errors" to the options with a list of "file:url" errors to ignore.