### PR TITLE
Fixed issue with manifest missing assets

### DIFF
--- a/django_manifeststaticfiles_enhanced/__init__.py
+++ b/django_manifeststaticfiles_enhanced/__init__.py
@@ -5,7 +5,7 @@ Enhanced ManifestStaticFilesStorage for Django with improvements from
 Django tickets: 27929, 21080, 26583, 28200, 34322
 """
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 
 from .storage import EnhancedManifestStaticFilesStorage
 

--- a/django_manifeststaticfiles_enhanced/storage.py
+++ b/django_manifeststaticfiles_enhanced/storage.py
@@ -66,9 +66,8 @@ class EnhancedHashedFilesMixin(HashedFilesMixin):
             name, hashed_name, processed = self._process_file(
                 name, paths[name], hashed_files, graph=graph
             )
-            if processed:
-                hashed_files[self.hash_key(self.clean_name(name))] = hashed_name
-                yield name, hashed_name, processed
+            hashed_files[self.hash_key(self.clean_name(name))] = hashed_name
+            yield name, hashed_name, processed
 
         # Handle circular dependencies
         if circular_deps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-manifeststaticfiles-enhanced"
-version = "0.4.3"
+version = "0.4.4"
 description = "Enhanced ManifestStaticFilesStorage for Django"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Some left over code was preventing the non_adjustable files from being added to the hashed_files dict and as a result the manifest file.