### PR TITLE
Add an option to resolve static paths in javascript

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This package includes several improvements to Django's `ManifestStaticFilesStora
 - **[ticket_23517](https://code.djangoproject.com/ticket/23517)**: Collect static files in parallel
 - **[ticket_36968](https://code.djangoproject.com/ticket/36968)**: Provide better error messages when collectstatic fails
 - **[new_feature 127](https://github.com/django/new-features/issues/127)**: Configurable using the OPTIONS dict of STORAGES setting
+- **staticjs**: JavaScript utility to access hashed static file paths in JavaScript
+
 ## Compatibility
 
 - **Django**: 4.2, 5.0, 5.1, 5.2, 6.0
@@ -189,6 +191,32 @@ keep_original_files = False
 # Results in: style.abc123.css only
 ```
 
+### JavaScript Static File Access (staticjs)
+
+Access hashed static file paths in JavaScript using the `django.static()` function:
+Add django-manifeststaticfiles-enhanced to your INSTALLED_APPS
+
+```html
+<!-- Include the django.js file in your template -->
+{% load staticjs $}
+
+{% include_staticjs %}
+
+<!-- Now you can use django.static() in your JavaScript -->
+<script src="dom_change.js"></script>
+```
+
+```js
+  // In development mode: returns "images/logo.png"
+  // In production mode: returns "images/logo.123abc.png"
+  const logoPath = django.static("images/logo.png");
+
+  // Use this path in your DOM manipulations
+  document.getElementById("logo").src = logoPath;
+```
+
+This feature is automatically added during collectstatic. The hashed version will be created and referenced correctly, similar to how Django's static template tag works.
+
 ### Ignoring specific errors
 
 Ignore specific errors during post-processing with the `ignore_errors` option. This is useful when you have third-party libraries that reference non-existent files or use dynamic path construction that can't be properly parsed.
@@ -272,6 +300,7 @@ This project is licensed under the BSD 3-Clause License - the same license as Dj
 
 ### 0.8.0
  - Added improved regex approach and made the lexer opt-in via use_lexer param
+ - Added JavaScript static file access utility (`staticjs/django.js`)
 
 ### 0.7.0
  - Add collectstatic command with parallelization, which can be customized with  --parallel option

--- a/django_manifeststaticfiles_enhanced/jslex.py
+++ b/django_manifeststaticfiles_enhanced/jslex.py
@@ -465,9 +465,9 @@ def find_import_export_strings(file_contents, should_ignore_url=None):
             if export_details:
                 matches.append(export_details)
         elif name == "id" and value == "django":
-            export_details = _extract_django_static_calls(tokens, i, should_ignore_url)
-            if export_details:
-                django_static_calls.append(export_details)
+            asset_name = _extract_django_static_calls(tokens, i, should_ignore_url)
+            if asset_name:
+                django_static_calls.append(asset_name)
 
     return matches, django_static_calls
 
@@ -477,7 +477,6 @@ def _extract_django_static_calls(tokens, i, should_ignore_url):
         i + 3 < len(tokens)
         and tokens[i + 1][0] == "punct"
         and tokens[i + 1][1] == "."
-        and tokens[i + 2][0] == "id"
         and tokens[i + 2][1] == "static"
         and tokens[i + 3][0] == "punct"
         and tokens[i + 3][1] == "("
@@ -485,9 +484,10 @@ def _extract_django_static_calls(tokens, i, should_ignore_url):
         # Find the string argument
         arg_index = i + 4
         if arg_index < len(tokens) and tokens[arg_index][0] == "string":
-            # Extract the string without quotes
-            return _format_match(tokens[arg_index], should_ignore_url)
-    return False
+            # Extract the string without quotes (no position needed, just the name)
+            match = _format_match(tokens[arg_index], should_ignore_url)
+            return match[0] if match else None
+    return None
 
 
 def _extract_import_details(tokens, i, should_ignore_url):

--- a/django_manifeststaticfiles_enhanced/jslex.py
+++ b/django_manifeststaticfiles_enhanced/jslex.py
@@ -452,6 +452,7 @@ def find_import_export_strings(file_contents, should_ignore_url=None):
         if token_tuple[0] not in ["ws", "comment", "linecomment"]
     ]
     matches = []
+    django_static_calls = []
 
     for i, (name, value, _) in enumerate(tokens):
         if name == "keyword" and value == "import":
@@ -463,8 +464,30 @@ def find_import_export_strings(file_contents, should_ignore_url=None):
             export_details = _extract_export_details(tokens, i, should_ignore_url)
             if export_details:
                 matches.append(export_details)
+        elif name == "id" and value == "django":
+            export_details = _extract_django_static_calls(tokens, i, should_ignore_url)
+            if export_details:
+                django_static_calls.append(export_details)
 
-    return matches
+    return matches, django_static_calls
+
+
+def _extract_django_static_calls(tokens, i, should_ignore_url):
+    if (
+        i + 3 < len(tokens)
+        and tokens[i + 1][0] == "punct"
+        and tokens[i + 1][1] == "."
+        and tokens[i + 2][0] == "id"
+        and tokens[i + 2][1] == "static"
+        and tokens[i + 3][0] == "punct"
+        and tokens[i + 3][1] == "("
+    ):
+        # Find the string argument
+        arg_index = i + 4
+        if arg_index < len(tokens) and tokens[arg_index][0] == "string":
+            # Extract the string without quotes
+            return _format_match(tokens[arg_index], should_ignore_url)
+    return False
 
 
 def _extract_import_details(tokens, i, should_ignore_url):

--- a/django_manifeststaticfiles_enhanced/static/staticjs/django.js
+++ b/django_manifeststaticfiles_enhanced/static/staticjs/django.js
@@ -1,0 +1,25 @@
+'use strict';
+{
+  const globals = this || globalThis || window || self || {};
+  const django = globals.django || (globals.django = {});
+
+  // Try to get the STATIC_URL from the script tag or fall back to "/static/"
+  let STATIC_URL = "/static/";
+
+  // Find the script tag with ID "staticjs-static-url"
+  const scriptTag = document.getElementById("staticjs-static-url");
+  if (scriptTag && scriptTag.dataset && scriptTag.dataset.staticUrl) {
+    STATIC_URL = scriptTag.dataset.staticUrl;
+  }
+
+  /**
+   * A simple function that returns the asset path in static_root in debug mode.
+   * In production, this function will be replaced with a version that maps assets to their hashed paths.
+   *
+   * @param {string} asset - The path to the static asset
+   * @returns {string} The static path
+   */
+  django.static = function(asset) {
+    return `${STATIC_URL}${asset}`;
+  };
+}

--- a/django_manifeststaticfiles_enhanced/storage.py
+++ b/django_manifeststaticfiles_enhanced/storage.py
@@ -1,3 +1,4 @@
+import json
 import os
 import posixpath
 import re
@@ -202,6 +203,7 @@ class StaticFileProcessingError(ValueError):
 
 
 class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
+    django_static_calls = []
 
     use_lexer = False
 
@@ -540,7 +542,7 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
             if not complex_adjustments:
                 return url_positions
 
-            # The simple search still leave lots of falst positives,
+            # The simple search still leave lots of false positives,
             # like the words important or exports
             # Match for import export syntax to futher reduce the need
             # to run the lexer, should cut out 90% of false positives
@@ -548,10 +550,11 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
                 return url_positions
 
             try:
-                urls = find_import_export_strings(
+                urls, django_static_calls = find_import_export_strings(
                     content,
                     should_ignore_url=lambda url: self._should_ignore_url(name, url),
                 )
+                self.django_static_calls += django_static_calls
             except ValueError as e:
                 message = e.args[0] if len(e.args) else ""
                 message = f"The js file '{name}' could not be processed.\n{message}"
@@ -972,12 +975,111 @@ class EnhancedManifestFilesMixin(EnhancedHashedFilesMixin, ManifestFilesMixin):
     """
 
     keep_original_files = True
+    staticjs_path = "staticjs/django.js"
 
     def post_process(self, *args, **kwargs):
         self.hashed_files = {}
         yield from super().post_process(*args, **kwargs)
         if not kwargs.get("dry_run"):
             self.save_manifest()
+
+            staticjs_result = self._create_staticjs_manifest(self.django_static_calls)
+            if staticjs_result:
+                yield staticjs_result
+
+    def _create_staticjs_manifest(self, referenced_assets):
+        """
+        Create a hashed version of django.js with manifest static paths.
+
+        Args:
+            referenced_assets: List of assets to include
+        """
+        # Skip if hashed_files is empty
+        if not self.hashed_files:
+            return
+
+        if self.staticjs_path not in self.hashed_files:
+            return
+        existing = self.hashed_files[self.staticjs_path]
+        if self.exists(existing):
+            self.delete(existing)
+
+        # Get filtered paths for static files
+        static_dict = self._get_filtered_static_paths(referenced_assets)
+
+        # Create the production version of django.js with the static dictionary
+        js_content = self._generate_staticjs_content(static_dict)
+
+        django_js = ContentFile(js_content.encode())
+        hashed_name = self.hashed_name(self.staticjs_path, django_js)
+
+        if not self.exists(hashed_name):
+            saved_name = self._save(hashed_name, django_js)
+            hashed_name = self.clean_name(saved_name)
+
+            self.hashed_files[self.hash_key(self.clean_name(self.staticjs_path))] = (
+                hashed_name
+            )
+
+            self.save_manifest()
+
+        return (self.staticjs_path, hashed_name, True)
+
+    def _get_filtered_static_paths(self, referenced_assets):
+        """
+        Get filtered static paths based on referenced assets.
+        Returns a dictionary of static paths with their hashed versions.
+
+        Args:
+            referenced_assets: List of assets to include
+        """
+        filtered_dict = {}
+
+        for name, hashed_name in self.hashed_files.items():
+            # Skip the django.js file itself (avoid self-reference)
+            if name == self.hash_key(self.clean_name(self.staticjs_path)):
+                continue
+
+            # New behavior: include only referenced assets
+            # or assets that don't match exclude patterns
+            if name not in referenced_assets:
+                continue
+
+            filtered_dict[name] = hashed_name
+
+        return filtered_dict
+
+    def _generate_staticjs_content(self, static_dict):
+        """
+        Generate the JavaScript content with the static dictionary.
+        """
+        static_dict_str = json.dumps(static_dict, separators=(",", ":"))
+        static_function = (
+            "'use strict';"
+            "{"
+            "const globals = this || globalThis || window || self || {};"
+            "const django = globals.django || (globals.django = {});"
+            'let STATIC_URL = "/static/";'
+            'const scriptTag = document.getElementById("staticjs-static-url");'
+            "if (scriptTag && scriptTag.dataset && scriptTag.dataset.staticUrl) {"
+            "STATIC_URL = scriptTag.dataset.staticUrl;"
+            "}"
+            f"const strict = {str(self.manifest_strict).lower()};"
+            f"const staticPaths = {static_dict_str};"
+            "django.static = function(asset) {"
+            "if (asset in staticPaths) {"
+            "return `${STATIC_URL}${staticPaths[asset]}`;"
+            "}"
+            "if (strict) {"
+            "console.error(`Static file '${asset}' not found in manifest`);"
+            "return"
+            "}"
+            "return staticPaths[asset];"
+            "};"
+            "}"
+        )
+
+        return static_function
 
 
 class EnhancedManifestStaticFilesStorage(
@@ -992,6 +1094,7 @@ class EnhancedManifestStaticFilesStorage(
     - ticket_34322: JsLex for ES module support
     - ignore_errors: List of 'file:url' errors to ignore during post-processing
     - Thread-safe storage for parallel collectstatic operations
+    - staticjs: JavaScript utility to access hashed static files paths in JavaScript
     """
 
     def __init__(
@@ -1004,6 +1107,7 @@ class EnhancedManifestStaticFilesStorage(
         keep_original_files=None,
         ignore_errors=None,
         use_lexer=None,
+        staticjs_exclude_patterns=None,
         *args,
         **kwargs,
     ):
@@ -1018,6 +1122,10 @@ class EnhancedManifestStaticFilesStorage(
             self.manifest_strict = manifest_strict
         if keep_original_files is not None:
             self.keep_original_files = keep_original_files
+        if staticjs_exclude_patterns is not None:
+            if not isinstance(staticjs_exclude_patterns, list):
+                raise ImproperlyConfigured("staticjs_exclude_patterns must be a list")
+            self.staticjs_exclude_patterns = staticjs_exclude_patterns
         if ignore_errors is not None:
             if not isinstance(ignore_errors, list):
                 raise ImproperlyConfigured("ignore_errors must be a list")

--- a/django_manifeststaticfiles_enhanced/storage.py
+++ b/django_manifeststaticfiles_enhanced/storage.py
@@ -538,15 +538,20 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
             complex_adjustments = "import" in content or (
                 "export" in content and "from" in content
             )
+            has_django_static = "django.static" in content
 
-            if not complex_adjustments:
+            if not complex_adjustments and not has_django_static:
                 return url_positions
 
             # The simple search still leave lots of false positives,
             # like the words important or exports
             # Match for import export syntax to futher reduce the need
             # to run the lexer, should cut out 90% of false positives
-            if not self.import_export_pattern.search(content):
+            if (
+                not complex_adjustments
+                and not has_django_static
+                and not self.import_export_pattern.search(content)
+            ):
                 return url_positions
 
             try:
@@ -563,17 +568,28 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
                 if self._should_adjust_url(url_name):
                     url_positions.append((url_name, position))
         else:
-            ignored_blocks = self.get_ignored_blocks(content, for_js=True)
             patterns = self._patterns.get("*.js", [])
-            if not any(p.search(content) for p, _ in patterns):
+            has_url_patterns = any(p.search(content) for p, _ in patterns)
+            has_django_static = "django.static" in content
+
+            if not has_url_patterns and not has_django_static:
                 return url_positions
-            for pattern, _ in patterns:
-                for match in pattern.finditer(content):
-                    if self.is_in_ignored_block(match.start(), ignored_blocks):
-                        continue
-                    url = match.group("url")
-                    if self._should_adjust_url(url):
-                        url_positions.append((url, match.start("url")))
+
+            ignored_blocks = self.get_ignored_blocks(content, for_js=True)
+
+            if has_url_patterns:
+                for pattern, _ in patterns:
+                    for match in pattern.finditer(content):
+                        if self.is_in_ignored_block(match.start(), ignored_blocks):
+                            continue
+                        url = match.group("url")
+                        if self._should_adjust_url(url):
+                            url_positions.append((url, match.start("url")))
+
+            if has_django_static:
+                for match in self.django_static_pattern.finditer(content):
+                    if not self.is_in_ignored_block(match.start(), ignored_blocks):
+                        self.django_static_calls.append(match.group("asset"))
 
         return url_positions
 
@@ -587,6 +603,11 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
         # check for the word export must be followed
         r"\bexport[\s{/*])",
         re.MULTILINE,
+    )
+
+    django_static_pattern = re.compile(
+        # Match django.static("asset") or django.static('asset')
+        r"""django\.static\(\s*(?P<quote>['"])(?P<asset>[^'"]+)(?P=quote)\s*\)"""
     )
 
     def _process_css_urls(self, name, content):
@@ -979,6 +1000,7 @@ class EnhancedManifestFilesMixin(EnhancedHashedFilesMixin, ManifestFilesMixin):
 
     def post_process(self, *args, **kwargs):
         self.hashed_files = {}
+        self.django_static_calls = []
         yield from super().post_process(*args, **kwargs)
         if not kwargs.get("dry_run"):
             self.save_manifest()

--- a/django_manifeststaticfiles_enhanced/templatetags/staticjs.py
+++ b/django_manifeststaticfiles_enhanced/templatetags/staticjs.py
@@ -1,0 +1,27 @@
+from django import template
+from django.conf import settings
+from django.templatetags.static import static
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.simple_tag
+def include_staticjs():
+    """
+    Template tag to include the staticjs/django.js file with proper static URL.
+
+    This template tag will generate a script tag with:
+    1. The proper hashed URL for staticjs/django.js
+    2. An ID attribute of "staticjs-static-url"
+    3. A data attribute with the STATIC_URL value
+
+    """
+    static_url = getattr(settings, "STATIC_URL", "/static/")
+    js_url = static("staticjs/django.js")
+    script_tag = (
+        f'<script src="{js_url}"'
+        f' id="staticjs-static-url" data-static-url="{static_url}"></script>'
+    )
+
+    return mark_safe(script_tag)

--- a/tests/staticfiles_tests/project/documents/cached/django_static.js
+++ b/tests/staticfiles_tests/project/documents/cached/django_static.js
@@ -1,0 +1,10 @@
+// Example usage of django.static() for resolving hashed static file paths.
+// During collectstatic these calls are detected so the referenced assets
+// are included in the generated staticjs/django.js manifest.
+
+const logoUrl = django.static("cached/img/relative.png");
+const iconUrl = django.static('cached/img/window.png');
+
+// These should NOT be detected (inside comments):
+// const ignored = django.static("cached/img/relative.png");
+/* const alsoIgnored = django.static("cached/img/window.png"); */

--- a/tests/staticfiles_tests/storage.py
+++ b/tests/staticfiles_tests/storage.py
@@ -111,3 +111,12 @@ class JSModuleImportAggregationManifestStorage(EnhancedManifestStaticFilesStorag
 class JSModuleImportAggregationManifestStorageLexer(EnhancedManifestStaticFilesStorage):
     support_js_module_import_aggregation = True
     use_lexer = True
+
+
+class DjangoStaticDetectionStorage(EnhancedManifestStaticFilesStorage):
+    use_lexer = False
+
+
+class DjangoStaticDetectionStorageLexer(EnhancedManifestStaticFilesStorage):
+    use_lexer = True
+    support_js_module_import_aggregation = True

--- a/tests/staticfiles_tests/test_jslex.py
+++ b/tests/staticfiles_tests/test_jslex.py
@@ -497,49 +497,49 @@ class FindImportExportStringsTest(SimpleTestCase):
     def test_import_statement_simple(self):
         """Test simple import statement."""
         js = 'import "module.js";'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "module.js")
 
     def test_import_statement_from(self):
         """Test import with from clause."""
         js = 'import { func } from "module.js";'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "module.js")
 
     def test_import_statement_default(self):
         """Test default import."""
         js = 'import React from "react.js";'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "react.js")
 
     def test_import_dynamic(self):
         """Test dynamic import."""
         js = 'import("module.js").then(m => m.default);'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "module.js")
 
     def test_export_from(self):
         """Test export from statement."""
         js = 'export { func } from "module.js";'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "module.js")
 
     def test_export_star_from(self):
         """Test export * from statement."""
         js = 'export * from "module.js";'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "module.js")
 
     def test_export_star_as_from(self):
         """Test export * as from statement."""
         js = 'export * as utils from "utils.js";'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "utils.js")
 
@@ -551,7 +551,7 @@ class FindImportExportStringsTest(SimpleTestCase):
         import utils from "./utils.js";
         export { helper } from "./helper.js";
         """
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 4)
         import_values = [imp[0] for imp in imports]
         self.assertIn("react.js", import_values)
@@ -562,16 +562,16 @@ class FindImportExportStringsTest(SimpleTestCase):
     def test_export_without_from(self):
         """Test export without from (should not be captured)."""
         js = "export const value = 42;"
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 0)
         js = 'export const value = 42; export { helper } from "./helper.js";'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         js = 'export { variable }; export { helper } from "./helper.js";'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         js = 'export { variable }\n export { helper } from "./helper.js";'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
 
     def test_import_with_comments(self):
@@ -586,7 +586,7 @@ class FindImportExportStringsTest(SimpleTestCase):
         import { Component } from /* "oldreact.js" */ "react.js";
         import(/* "oldreact.js" */ "react.js")
         """
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 4)
         import_values = [imp[0] for imp in imports]
         self.assertEqual(import_values.count("react.js"), 4)
@@ -601,7 +601,7 @@ class FindImportExportStringsTest(SimpleTestCase):
         */
         import { Component } from /* "oldmodule.js" */ "module.js";
         """
-        exports = find_import_export_strings(js)
+        exports, _ = find_import_export_strings(js)
         self.assertEqual(len(exports), 2)
         export_values = [imp[0] for imp in exports]
         self.assertEqual(export_values.count("module.js"), 2)
@@ -614,7 +614,7 @@ class FindImportExportStringsTest(SimpleTestCase):
             return x * 2;
         }
         """
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 0)
 
     def test_poor_syntax(self):
@@ -623,7 +623,7 @@ class FindImportExportStringsTest(SimpleTestCase):
         import utils for "./utils.js";
         export *;
         """
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 0)
 
     def test_template_literal_with_import_like_content(self):
@@ -632,7 +632,7 @@ class FindImportExportStringsTest(SimpleTestCase):
         const code = `import React from "react";`;
         import utils from "./utils.js";
         """
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         # Should only capture the actual import, not the template literal content
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "./utils.js")
@@ -645,7 +645,7 @@ class FindImportExportStringsTest(SimpleTestCase):
         import * as name from "namespace.js";
         import defaultExport, * as name from "mixed.js";
         """
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 4)
         import_values = [imp[0] for imp in imports]
         self.assertIn("module.js", import_values)

--- a/tests/staticfiles_tests/test_staticjs.py
+++ b/tests/staticfiles_tests/test_staticjs.py
@@ -1,0 +1,119 @@
+"""
+Tests for the staticjs functionality in EnhancedManifestStaticFilesStorage
+"""
+
+import tempfile
+
+from django.conf import STATICFILES_STORAGE_ALIAS, settings
+from django.test import TestCase, override_settings
+
+from django_manifeststaticfiles_enhanced.storage import (
+    EnhancedManifestStaticFilesStorage,
+)
+
+
+@override_settings(
+    STATIC_URL="/static/",
+    STATIC_ROOT=tempfile.mkdtemp(),
+    STORAGES={
+        **settings.STORAGES,
+        STATICFILES_STORAGE_ALIAS: {
+            "BACKEND": (
+                "django_manifeststaticfiles_enhanced.storage."
+                "EnhancedManifestStaticFilesStorage"
+            ),
+        },
+    },
+)
+class StaticJSTest(TestCase):
+    """Test the staticjs functionality"""
+
+    def setUp(self):
+        self.storage = EnhancedManifestStaticFilesStorage()
+
+    def test_staticjs_custom_settings(self):
+        """Test that staticjs settings can be customized"""
+        storage = EnhancedManifestStaticFilesStorage(
+            staticjs_exclude_patterns=["*.foo"],
+        )
+        self.assertEqual(storage.staticjs_exclude_patterns, ["*.foo"])
+
+    def test_staticjs_manifest_creation(self):
+        """Test that staticjs creates a manifest JS file"""
+        # Set up mock hashed files
+        self.storage.hashed_files = {
+            "image.png": "image.123abc.png",
+            "data.json": "data.456def.json",
+            # Add a JS file that should be excluded by default
+            "script.js": "script.789ghi.js",
+            "staticjs/django.js": "staticjs/django.123jkl.js",
+        }
+
+        # Create the staticjs manifest
+        referenced_assets = ["image.png"]
+        results = self.storage._create_staticjs_manifest(referenced_assets)
+
+        name, hashed_name, processed = results
+        self.assertEqual(name, "staticjs/django.js")
+        self.assertTrue(hashed_name.startswith("staticjs/django."))
+        self.assertTrue(hashed_name.endswith(".js"))
+        self.assertTrue(processed)
+
+        # Check that the staticjs file was added to hashed_files
+        self.assertIn(
+            self.storage.hash_key(self.storage.clean_name("staticjs/django.js")),
+            self.storage.hashed_files,
+        )
+
+    def test_filtered_static_paths(self):
+        """Test that staticjs correctly filters static paths"""
+        # Set up mock hashed files
+        self.storage.hashed_files = {
+            "image.png": "image.123abc.png",
+            "data.json": "data.456def.json",
+            "script.js": "script.789ghi.js",
+            "style.css": "style.abc123.css",
+            "script.ts": "script.def456.ts",
+            "staticjs/django.js": "staticjs/django.xyz789.js",
+        }
+
+        # Get filtered paths
+        referenced_assets = ["image.png", "data.json"]
+        filtered_dict = self.storage._get_filtered_static_paths(referenced_assets)
+
+        # Check that JS, CSS, TS files are excluded by default
+        self.assertIn("image.png", filtered_dict)
+        self.assertIn("data.json", filtered_dict)
+        self.assertNotIn("script.js", filtered_dict)
+        self.assertNotIn("style.css", filtered_dict)
+        self.assertNotIn("script.ts", filtered_dict)
+        self.assertNotIn("staticjs/django.js", filtered_dict)
+
+        # Verify values
+        self.assertEqual(filtered_dict["image.png"], "image.123abc.png")
+        self.assertEqual(filtered_dict["data.json"], "data.456def.json")
+
+    def test_staticjs_content_generation(self):
+        """Test the generated JS content"""
+        # Set up a dictionary of static paths
+        static_dict = {
+            "image.png": "image.123abc.png",
+            "data.json": "data.456def.json",
+            "staticjs/django.js": "staticjs/django.xyz789.js",
+        }
+
+        # Generate JS content with strict mode
+        self.storage.manifest_strict = True
+        strict_js = self.storage._generate_staticjs_content(static_dict)
+
+        # Check that the content contains the static dictionary and strict=true
+        self.assertIn('"image.png":"image.123abc.png"', strict_js)
+        self.assertIn('"data.json":"data.456def.json"', strict_js)
+        self.assertIn("const strict = true", strict_js)
+
+        # Generate JS content with non-strict mode
+        self.storage.manifest_strict = False
+        non_strict_js = self.storage._generate_staticjs_content(static_dict)
+
+        # Check that the content contains strict=false
+        self.assertIn("const strict = false", non_strict_js)

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -1723,3 +1723,96 @@ class TestTestingManifestStaticFilesStorage(CollectionTestCase):
         self.assertStaticRaises(
             ValueError, "does/not/exist.png", "/static/does/not/exist.png"
         )
+
+
+class DjangoStaticDetectionTestMixin:
+    """
+    Shared assertions for django.static() call detection in JS files.
+
+    The fixture cached/django_static.js illustrates the intended usage pattern.
+    These tests call _process_js_modules directly so detection can be verified
+    without depending on collectstatic's internal storage instance.
+    Tests run against both paths via the two subclasses below.
+    """
+
+    # set in each subclass
+    storage_class = None
+
+    def setUp(self):
+        super().setUp()
+        self.st = self.storage_class()
+
+    def _detect(self, js_content):
+        self.st.django_static_calls = []
+        self.st._process_js_modules("app.js", js_content)
+        return self.st.django_static_calls
+
+    def test_calls_detected(self):
+        """Assets passed to django.static() are recorded."""
+        # mirrors the real calls in the fixture cached/django_static.js
+        js = (
+            'const logoUrl = django.static("cached/img/relative.png");\n'
+            "const iconUrl = django.static('cached/img/window.png');"
+        )
+        calls = self._detect(js)
+        self.assertIn("cached/img/relative.png", calls)
+        self.assertIn("cached/img/window.png", calls)
+
+    def test_line_comment_ignored(self):
+        """django.static() inside a // comment is not recorded."""
+        calls = self._detect(
+            '// const ignored = django.static("cached/img/relative.png");'
+        )
+        self.assertEqual(calls, [])
+
+    def test_block_comment_ignored(self):
+        """django.static() inside a /* */ comment is not recorded."""
+        calls = self._detect(
+            '/* const ignored = django.static("cached/img/relative.png"); */'
+        )
+        self.assertEqual(calls, [])
+
+    def test_real_call_alongside_comment(self):
+        """A real call is detected even when a commented call is present."""
+        js = (
+            '// django.static("cached/img/relative.png")\n'
+            'django.static("cached/img/window.png");'
+        )
+        calls = self._detect(js)
+        self.assertNotIn("cached/img/relative.png", calls)
+        self.assertIn("cached/img/window.png", calls)
+
+    def test_no_calls(self):
+        """Files with no django.static() calls produce an empty list."""
+        calls = self._detect("const x = 1; console.log(x);")
+        self.assertEqual(calls, [])
+
+    def test_non_js_file_skipped(self):
+        """Non-JS files are not processed."""
+        self.st.django_static_calls = []
+        self.st._process_js_modules("style.css", 'django.static("a.png")')
+        self.assertEqual(self.st.django_static_calls, [])
+
+
+class TestDjangoStaticDetectionRegex(DjangoStaticDetectionTestMixin, SimpleTestCase):
+    """
+    django.static() detection via the default regex path (use_lexer=False).
+
+    The fixture cached/django_static.js demonstrates the intended usage:
+        const logoUrl = django.static("cached/img/relative.png");
+        const iconUrl = django.static('cached/img/window.png');
+    """
+
+    from staticfiles_tests.storage import DjangoStaticDetectionStorage
+
+    storage_class = DjangoStaticDetectionStorage
+
+
+class TestDjangoStaticDetectionLexer(DjangoStaticDetectionTestMixin, SimpleTestCase):
+    """
+    django.static() detection via the jslex tokeniser (use_lexer=True).
+    """
+
+    from staticfiles_tests.storage import DjangoStaticDetectionStorageLexer
+
+    storage_class = DjangoStaticDetectionStorageLexer

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -264,7 +264,9 @@ class TestHashedFiles:
             os.path.join("cached", "css", "img", "window.png"), stats["unmodified"]
         )
         self.assertIn(os.path.join("test", "nonascii.css"), stats["post_processed"])
-        # No file should be yielded twice.
+        # No file should be yielded twice, except staticjs/django.js
+        if stats["post_processed"][-1] == "staticjs/django.js":
+            del stats["post_processed"][-1]
         self.assertCountEqual(stats["post_processed"], set(stats["post_processed"]))
         self.assertPostCondition()
 

--- a/tests/staticfiles_tests/test_templatetags.py
+++ b/tests/staticfiles_tests/test_templatetags.py
@@ -1,0 +1,40 @@
+"""
+Tests for the staticjs template tags
+"""
+
+import tempfile
+
+from django.conf import STATICFILES_STORAGE_ALIAS, settings
+from django.template import Context, Template
+from django.test import TestCase, override_settings
+
+
+@override_settings(
+    STATIC_URL="/static/",
+    STATIC_ROOT=tempfile.mkdtemp(),
+    STORAGES={
+        **settings.STORAGES,
+        STATICFILES_STORAGE_ALIAS: {
+            "BACKEND": ("django.contrib.staticfiles.storage.StaticFilesStorage"),
+        },
+    },
+    INSTALLED_APPS=[
+        "django.contrib.staticfiles",
+        "django_manifeststaticfiles_enhanced",
+    ],
+)
+class StaticJSTemplateTagTest(TestCase):
+    """Test the staticjs template tags"""
+
+    def test_include_staticjs_tag(self):
+        """Test that the include_staticjs tag works correctly"""
+        # Create a template that uses the include_staticjs tag
+        template = Template("{% load staticjs %}" "{% include_staticjs %}")
+
+        # Render the template
+        rendered = template.render(Context({}))
+
+        # Check that it contains the correct structure
+        self.assertIn('<script src="/static/staticjs/django.js"', rendered)
+        self.assertIn('id="staticjs-static-url"', rendered)
+        self.assertIn('data-static-url="/static/"', rendered)


### PR DESCRIPTION
The ManifestStaticFilesStorage will replace import/export statements in javascript, and url() statements in css. But if for example you do dom manipulations in javascript and want to reference a static file you have to roll your own sollution to reference the correct static file. Typically you will call the static command in a template and pass it to javascript as a data attribute or in a script of type=application/json, see this classic [stack overflow](https://stackoverflow.com/questions/27932983/django-static-path-in-javascript-file) example

This is a proposal to add a generic `django.static` function to the javascript namespace, by using the template tag `{% include_staticjs %}`. This then allows you to use `django.static("image.png")` in your javascript and it will return the correct path eg, `"/static/image.123xyz.png"`

This makes it more convenient to use static files in javascript when doing dom manipulations, etc.
It would probably be possible that collectstatic changes the javascript files, instead of using a javascript funciton, but this wouldn't work for development and it seems better to keep them working the same way.