### PR TITLE
Improved performance

### DIFF
--- a/django_manifeststaticfiles_enhanced/__init__.py
+++ b/django_manifeststaticfiles_enhanced/__init__.py
@@ -5,7 +5,7 @@ Enhanced ManifestStaticFilesStorage for Django with improvements from
 Django tickets: 27929, 21080, 26583, 28200, 34322
 """
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 
 from .storage import EnhancedManifestStaticFilesStorage
 

--- a/django_manifeststaticfiles_enhanced/jslex.py
+++ b/django_manifeststaticfiles_enhanced/jslex.py
@@ -471,6 +471,11 @@ def _extract_import_details(tokens, i, should_ignore_url):
     if i > 0 and tokens[i - 1][0] == "punct" and tokens[i - 1][1] == ".":
         return False
 
+    # Check if this is actually a key in a dictionary
+    # by looking at the next token if it's a : then this is a key
+    if i + 1 < len(tokens) and tokens[i + 1][0] == "punct" and tokens[i + 1][1] == ":":
+        return False
+
     # check for plain import and function imports first
     # import "module-name";
     if i + 1 < len(tokens) and tokens[i + 1][0] == "string":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-manifeststaticfiles-enhanced"
-version = "0.4.5"
+version = "0.4.6"
 description = "Enhanced ManifestStaticFilesStorage for Django"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
After testing with some real world projects, I noticed that alot of times the lexer is getting called for css/js that has no need of them. The fix for css was easy search for `@import` instead of just import which then rules out lots of files that have `!important` but no import statement.

The javascript one requires to use some regular expressions to search for whole word import/export instead of just the bare string. It still makes sense to do the bare search first as it can rule out 90% of js files which won't have either word. Even most those that do aren't using import export features. So rather than limiting to just search for the whole words we can use our knowledge of the syntax to rule out some more false positives like dictionary keywords. This still will leave some false positives like comments object functions named import. But that is why we have the lexer in the first place.