### PR TITLE
Made support of js import/export statements opt in

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ STORAGES = {
 
 #### JavaScript Module Support ([ticket_34322](https://code.djangoproject.com/ticket/34322))
 
-Disable ES module import/export processing:
+Enable ES module import/export processing:
 
 ```python
 # settings.py
@@ -79,7 +79,7 @@ STORAGES = {
     "staticfiles": {
         "BACKEND": "django_manifeststaticfiles_enhanced.storage.EnhancedManifestStaticFilesStorage",
         "OPTIONS": {
-            "support_js_module_import_aggregation": False,
+            "support_js_module_import_aggregation": True,
         },
     },
 }
@@ -121,11 +121,11 @@ Reduces unnecessary file operations during `collectstatic`:
 
 ### JavaScript Module Support ([ticket_34322](https://code.djangoproject.com/ticket/34322))
 
-Enabled by default:
+JS import/export processing uses a proper lexer instead of regex, providing:
 
-- Processes ES6 import/export statements
-- Handles dynamic imports
-- Updates module paths to hashed versions
+- Covers ES6 import/export statements and dynamic imports
+- Ignores statements in comments and strings
+- Supports assert statements in imports, `import sheet from './styles.css' assert { type: 'css' };`
 
 Example JavaScript that gets processed:
 
@@ -208,6 +208,10 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 This project is licensed under the BSD 3-Clause License - the same license as Django.
 
 ## Changelog
+
+### 0.5.0
+
+- Made support of js import/export statements opt in
 
 ### 0.4.0
 

--- a/django_manifeststaticfiles_enhanced/__init__.py
+++ b/django_manifeststaticfiles_enhanced/__init__.py
@@ -5,7 +5,7 @@ Enhanced ManifestStaticFilesStorage for Django with improvements from
 Django tickets: 27929, 21080, 26583, 28200, 34322
 """
 
-__version__ = "0.4.6"
+__version__ = "0.5.0"
 
 from .storage import EnhancedManifestStaticFilesStorage
 

--- a/django_manifeststaticfiles_enhanced/storage.py
+++ b/django_manifeststaticfiles_enhanced/storage.py
@@ -29,7 +29,6 @@ class ProcessingException(Exception):
 
 
 class EnhancedHashedFilesMixin(HashedFilesMixin):
-    support_js_module_import_aggregation = True
 
     def post_process(self, paths, dry_run=False, **options):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-manifeststaticfiles-enhanced"
-version = "0.4.6"
+version = "0.5.0"
 description = "Enhanced ManifestStaticFilesStorage for Django"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Having tested out this in #34, it makes more sense for the support of js files to remain optin. It was originally added as an option as the support was flaky. Although this package makes it robust, it is still not relevaant functionality for the majority of projects, and comes with a performance and occasionaly configuration headache (if you are including webpack files in your static folder)