### PR TITLE
Surface exceptions with static tag when DEBUG=True

### DIFF
--- a/django_manifeststaticfiles_enhanced/__init__.py
+++ b/django_manifeststaticfiles_enhanced/__init__.py
@@ -5,8 +5,11 @@ Enhanced ManifestStaticFilesStorage for Django with improvements from
 Django tickets: 27929, 21080, 26583, 28200, 34322
 """
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
-from .storage import EnhancedManifestStaticFilesStorage
+from .storage import (
+    EnhancedManifestStaticFilesStorage,
+    TestingManifestStaticFilesStorage,
+)
 
-__all__ = ["EnhancedManifestStaticFilesStorage"]
+__all__ = ["EnhancedManifestStaticFilesStorage", "TestingManifestStaticFilesStorage"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-manifeststaticfiles-enhanced"
-version = "0.5.0"
+version = "0.6.0"
 description = "Enhanced ManifestStaticFilesStorage for Django"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/tests/staticfiles_tests/storage.py
+++ b/tests/staticfiles_tests/storage.py
@@ -103,5 +103,5 @@ class NoneHashStorage(EnhancedManifestStaticFilesStorage):
         return None
 
 
-class NoPostProcessReplacedPathStorage(EnhancedManifestStaticFilesStorage):
-    max_post_process_passes = 0
+class JSModuleImportAggregationManifestStorage(EnhancedManifestStaticFilesStorage):
+    support_js_module_import_aggregation = True


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26329 raises that the normal StaticFilesStorage and ManifestStaticFilesStorage react differently to a call to the static tag with a / in front of it. StaticFilesStorage ignores the / where has ManifestStaticFilesStorage does a look up for that exact url in the manifest file, which isn't there so it throws a value error.
When DEBUG=True, and ManifestStaticFilesStorage is configured it will not do the manifest look up for better develoiper experience. It essentially falls back to StaticFilesStorage. 
This can lead to missed errors in your code in development that only become apparent when run with collectstatic and DEBUG=False, which may not be till production.
I've been running this gist for years to help with it.
https://gist.github.com/blighj/08a2e4590d9fdd05c145a5c139c45966

This PR brings that to this package.