### PR TITLE
Downgrade missing sourcemaps to a warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ STORAGES = {
 }
 ```
 
-#### Raising missing Sourcemap warnings to exceptions
+#### Raising missing Sourcemap warnings as exceptions
 
-By default missing sourcmap links in js/css files will not cuase an exception
+Unlike django, missing sourcmap links in js/css files will not cuase an exception
 that prevents other processing, but will only produce a warning. This can be
-changed to an exceoption, like in django by setting `sourcemap_strict`.
+changed to an exceoption to match django by setting `sourcemap_strict`.
 
 ```python
 # settings.py

--- a/README.md
+++ b/README.md
@@ -116,6 +116,24 @@ STORAGES = {
 }
 ```
 
+#### Raising missing Sourcemap warnings to exceptions
+
+By default missing sourcmap links in js/css files will not cuase an exception
+that prevents other processing, but will only produce a warning. This can be
+changed to an exceoption, like in django by setting `sourcemap_strict`.
+
+```python
+# settings.py
+STORAGES = {
+    "staticfiles": {
+        "BACKEND": "django_manifeststaticfiles_enhanced.storage.EnhancedManifestStaticFilesStorage",
+        "OPTIONS": {
+            "sourcemap_strict": True,
+        },
+    },
+}
+```
+
 #### Easy access to existing options
 Disable [manifest_strict](https://docs.djangoproject.com/en/5.2/ref/contrib/staticfiles/#django.contrib.staticfiles.storage.ManifestStaticFilesStorage.manifest_strict)
 ```python
@@ -269,6 +287,9 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 This project is licensed under the BSD 3-Clause License - the same license as Django.
 
 ## Changelog
+
+### dev
+ - Only warn on missing sourcemaps, with `sourcemap_strict` option to restore old behaviour of ending all proceesing with an error.
 
 ### 0.8.0
  - Added improved regex approach and made the lexer opt-in via use_lexer param

--- a/django_manifeststaticfiles_enhanced/__init__.py
+++ b/django_manifeststaticfiles_enhanced/__init__.py
@@ -9,7 +9,12 @@ __version__ = "0.8.0"
 
 from .storage import (
     EnhancedManifestStaticFilesStorage,
+    SourcemapWarning,
     TestingManifestStaticFilesStorage,
 )
 
-__all__ = ["EnhancedManifestStaticFilesStorage", "TestingManifestStaticFilesStorage"]
+__all__ = [
+    "EnhancedManifestStaticFilesStorage",
+    "SourcemapWarning",
+    "TestingManifestStaticFilesStorage",
+]

--- a/django_manifeststaticfiles_enhanced/management/commands/collectstatic.py
+++ b/django_manifeststaticfiles_enhanced/management/commands/collectstatic.py
@@ -15,6 +15,8 @@ from django.contrib.staticfiles.management.commands.collectstatic import (
 )
 from django.core.management.base import CommandError
 
+from django_manifeststaticfiles_enhanced.storage import SourcemapWarning
+
 # Global lock for directory creation in link operations
 _link_makedirs_lock = threading.Lock()
 
@@ -139,7 +141,9 @@ class Command(DjangoCollectstaticCommand):
         if self.post_process and hasattr(self.storage, "post_process"):
             processor = self.storage.post_process(found_files, dry_run=self.dry_run)
             for original_path, processed_path, processed in processor:
-                if isinstance(processed, Exception):
+                if isinstance(processed, SourcemapWarning):
+                    self.log(str(processed), level=1)
+                elif isinstance(processed, Exception):
                     self.stderr.write("Post-processing '%s' failed!" % original_path)
                     self.stderr.write()
                     # Re-raise exceptions as CommandError and display notes.

--- a/django_manifeststaticfiles_enhanced/storage.py
+++ b/django_manifeststaticfiles_enhanced/storage.py
@@ -353,23 +353,36 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
         """
         substitutions_dict = self._find_substitutions(paths)
         for name, url_positions in substitutions_dict.items():
-            for url, _, is_sourcemap in url_positions:
+            storage, path = paths[name]
+            with storage.open(path) as f:
+                content = f.read().decode("utf-8")
+            for url, position, is_sourcemap in url_positions:
                 try:
                     self._adjust_url(url, name, paths)
                 except ValueError as exc:
                     if self._should_ignore_url(name, url):
                         pass
                     elif is_sourcemap and not self.sourcemap_strict:
+                        line = _line_at_position(content, position)
                         self._sourcemap_warnings.append(
                             (
                                 name,
                                 SourcemapWarning(
                                     f"{name!r}: sourcemap reference {url!r} "
+                                    "on line {line} "
                                     "could not be resolved"
                                 ),
                             )
                         )
                     else:
+                        line = _line_at_position(content, position)
+                        note = (
+                            f"{name!r} contains this reference {url!r} on line {line}"
+                        )
+                        if hasattr(exc, "add_note"):
+                            exc.add_note(note)
+                        else:
+                            exc.args = (f"{exc.args[0]}\n{note}" if exc.args else note,)
                         raise StaticFileProcessingError(name) from exc
 
     def _post_process(self, paths):

--- a/django_manifeststaticfiles_enhanced/storage.py
+++ b/django_manifeststaticfiles_enhanced/storage.py
@@ -201,9 +201,14 @@ class StaticFileProcessingError(ValueError):
         self.file_name = file_name
 
 
+class SourcemapWarning(UserWarning):
+    pass
+
+
 class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
 
     use_lexer = False
+    sourcemap_strict = False
 
     # Override Django's base patterns to fix greedy .* in source map patterns.
     # The greedy .* captures trailing whitespace (tabs, spaces) into the url
@@ -326,10 +331,13 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
         If either of these are performed on a file, then that file is
         considered post-processed.
         """
+        self._sourcemap_warnings = []
         try:
             # if we're in dry run, still find urls and raise any exceptions
             if dry_run:
                 self._test_url_substitutions(paths)
+                for warn_name, warning in self._sourcemap_warnings:
+                    yield warn_name, warn_name, warning
                 return
 
             # Process files using the dependency graph
@@ -345,11 +353,23 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
         """
         substitutions_dict = self._find_substitutions(paths)
         for name, url_positions in substitutions_dict.items():
-            for url, _ in url_positions:
+            for url, _, is_sourcemap in url_positions:
                 try:
                     self._adjust_url(url, name, paths)
                 except ValueError as exc:
-                    if not self._should_ignore_url(name, url):
+                    if self._should_ignore_url(name, url):
+                        pass
+                    elif is_sourcemap and not self.sourcemap_strict:
+                        self._sourcemap_warnings.append(
+                            (
+                                name,
+                                SourcemapWarning(
+                                    f"{name!r}: sourcemap reference {url!r} "
+                                    "could not be resolved"
+                                ),
+                            )
+                        )
+                    else:
                         raise StaticFileProcessingError(name) from exc
 
     def _post_process(self, paths):
@@ -410,6 +430,9 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
             )
             hashed_files[self.hash_key(self.clean_name(name))] = hashed_name
             yield name, hashed_name, processed
+            for warn_name, warning in self._sourcemap_warnings:
+                yield warn_name, warn_name, warning
+            self._sourcemap_warnings.clear()
 
         # Phase 3: Handle circular dependencies
         if circular_deps:
@@ -419,6 +442,9 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
             for name, hashed_name in circular_hashes:
                 hashed_files[self.hash_key(self.clean_name(name))] = hashed_name
                 yield name, hashed_name, True
+            for warn_name, warning in self._sourcemap_warnings:
+                yield warn_name, warn_name, warning
+            self._sourcemap_warnings.clear()
 
         # Store the processed paths
         self.hashed_files.update(hashed_files)
@@ -470,7 +496,11 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
                 url_positions = []
                 for finder in finders:
                     url_positions.extend(finder(name, content))
-                substitutions_dict[name] = url_positions
+                # Normalize to 3-tuples for backward compat with custom finders
+                # that return (url, position) 2-tuples without is_sourcemap.
+                substitutions_dict[name] = [
+                    item if len(item) == 3 else (*item, False) for item in url_positions
+                ]
         return substitutions_dict
 
     def _topological_sort(self, paths, substitutions_dict):
@@ -494,7 +524,7 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
         # build the graph based on the substitutions_dict
         for name, url_positions in substitutions_dict.items():
             if url_positions:
-                for url_name, _ in url_positions:
+                for url_name, *_ in url_positions:
                     # normalise base.css, /static/base.css, ../base.css, etc
                     target = self._get_target_name(url_name, name)
                     graph_sorter.add(name, target)
@@ -558,19 +588,20 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
                 raise StaticFileProcessingError(name) from ValueError(message)
             for url_name, position in urls:
                 if self._should_adjust_url(url_name):
-                    url_positions.append((url_name, position))
+                    url_positions.append((url_name, position, False))
         else:
             ignored_blocks = self.get_ignored_blocks(content, for_js=True)
             patterns = self._patterns.get("*.js", [])
             if not any(p.search(content) for p, _ in patterns):
                 return url_positions
             for pattern, _ in patterns:
+                is_sourcemap = "sourceMappingURL" in pattern.pattern
                 for match in pattern.finditer(content):
                     if self.is_in_ignored_block(match.start(), ignored_blocks):
                         continue
                     url = match.group("url")
                     if self._should_adjust_url(url):
-                        url_positions.append((url, match.start("url")))
+                        url_positions.append((url, match.start("url"), is_sourcemap))
 
         return url_positions
 
@@ -602,19 +633,20 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
 
             for url_name, position in extract_css_urls(content):
                 if self._should_adjust_url(url_name):
-                    url_positions.append((url_name, position))
+                    url_positions.append((url_name, position, False))
         else:
             ignored_blocks = self.get_ignored_blocks(content)
             patterns = self._patterns.get("*.css", [])
             if not any(p.search(content) for p, _ in patterns):
                 return url_positions
             for pattern, _ in patterns:
+                is_sourcemap = "sourceMappingURL" in pattern.pattern
                 for match in pattern.finditer(content):
                     if self.is_in_ignored_block(match.start(), ignored_blocks):
                         continue
                     url = match.group("url")
                     if self._should_adjust_url(url):
-                        url_positions.append((url, match.start("url")))
+                        url_positions.append((url, match.start("url"), is_sourcemap))
 
         return url_positions
 
@@ -628,7 +660,7 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
                 for match in pattern.finditer(content):
                     url = match.group("url")
                     if self._should_adjust_url(url):
-                        url_positions.append((url, match.start("url")))
+                        url_positions.append((url, match.start("url"), True))
         return url_positions
 
     source_map_patterns = {
@@ -775,7 +807,7 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
     def _process_file_content(self, name, content, url_positions, hashed_files):
         """
         Process file content by substituting URLs.
-        url_positions is a list of (url, position) tuples.
+        url_positions is a list of (url, position, is_sourcemap) tuples.
         """
         if not url_positions:
             return content
@@ -789,7 +821,7 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
             key=lambda x: x[1],
         )
 
-        for url, pos in sorted_positions:
+        for url, pos, is_sourcemap in sorted_positions:
             position = pos
             # Add content before this URL
             result_parts.append(content[last_position:position])
@@ -798,6 +830,18 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
                 transformed_url = self._adjust_url(url, name, hashed_files)
             except ValueError as exc:
                 if self._should_ignore_url(name, url):
+                    transformed_url = url
+                elif is_sourcemap and not self.sourcemap_strict:
+                    line = _line_at_position(content, position)
+                    self._sourcemap_warnings.append(
+                        (
+                            name,
+                            SourcemapWarning(
+                                f"{name!r}: sourcemap reference {url!r} on line {line} "
+                                "could not be resolved, leaving as-is"
+                            ),
+                        )
+                    )
                     transformed_url = url
                 else:
                     line = _line_at_position(content, position)
@@ -893,10 +937,10 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
 
                 # Filter URL positions to only non-circular dependencies
                 non_circular_positions = []
-                for url, pos in substitutions_dict.get(name, []):
+                for url, pos, is_sourcemap in substitutions_dict.get(name, []):
                     target = self._get_target_name(url, name)
                     if target not in circular_deps:
-                        non_circular_positions.append((url, pos))
+                        non_circular_positions.append((url, pos, is_sourcemap))
                 # Replace all non-circular URLs first
                 if non_circular_positions:
                     content = self._process_file_content(
@@ -1004,6 +1048,7 @@ class EnhancedManifestStaticFilesStorage(
         keep_original_files=None,
         ignore_errors=None,
         use_lexer=None,
+        sourcemap_strict=None,
         *args,
         **kwargs,
     ):
@@ -1026,6 +1071,8 @@ class EnhancedManifestStaticFilesStorage(
             self.ignore_errors = []
         if use_lexer is not None:
             self.use_lexer = use_lexer
+        if sourcemap_strict is not None:
+            self.sourcemap_strict = sourcemap_strict
         super().__init__(location, base_url, *args, **kwargs)
 
 

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -415,6 +415,93 @@ class TestHashedFiles:
         self.assertEqual("Post-processing 'nonutf8.css' failed!\n\n", err.getvalue())
         self.assertPostCondition()
 
+    def test_missing_css_sourcemap_warns(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with open(
+                os.path.join(temp_dir, "missing_sourcemap.css"), "w", newline="\n"
+            ) as f:
+                f.write(
+                    "* {outline: 1px solid red;}\n"
+                    "/*# sourceMappingURL=missing.css.map*/\n"
+                )
+            with override_settings(
+                STATICFILES_DIRS=[temp_dir],
+                STATICFILES_FINDERS=[
+                    "django.contrib.staticfiles.finders.FileSystemFinder"
+                ],
+            ):
+                finders.get_finder.cache_clear()
+                out = StringIO()
+                call_command(
+                    "collectstatic",
+                    interactive=False,
+                    verbosity=1,
+                    stdout=out,
+                )
+                self.assertIn("missing.css.map", out.getvalue())
+                self.assertPostCondition()
+
+    def test_missing_js_sourcemap_warns(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with open(
+                os.path.join(temp_dir, "missing_sourcemap.js"), "w", newline="\n"
+            ) as f:
+                f.write("//# sourceMappingURL=missing.js.map\nlet a_variable = 1;\n")
+            with override_settings(
+                STATICFILES_DIRS=[temp_dir],
+                STATICFILES_FINDERS=[
+                    "django.contrib.staticfiles.finders.FileSystemFinder"
+                ],
+            ):
+                finders.get_finder.cache_clear()
+                out = StringIO()
+                call_command(
+                    "collectstatic",
+                    interactive=False,
+                    verbosity=1,
+                    stdout=out,
+                )
+                self.assertIn("missing.js.map", out.getvalue())
+                self.assertPostCondition()
+
+    def test_missing_sourcemap_leaves_reference_intact(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with open(
+                os.path.join(temp_dir, "missing_sourcemap.css"), "w", newline="\n"
+            ) as f:
+                f.write(
+                    "* {outline: 1px solid red;}\n"
+                    "/*# sourceMappingURL=missing.css.map*/\n"
+                )
+            with open(
+                os.path.join(temp_dir, "missing_sourcemap.js"), "w", newline="\n"
+            ) as f:
+                f.write("//# sourceMappingURL=missing.js.map\nlet a_variable = 1;\n")
+            with override_settings(
+                STATICFILES_DIRS=[temp_dir],
+                STATICFILES_FINDERS=[
+                    "django.contrib.staticfiles.finders.FileSystemFinder"
+                ],
+            ):
+                finders.get_finder.cache_clear()
+                call_command(
+                    "collectstatic",
+                    interactive=False,
+                    verbosity=0,
+                    stderr=StringIO(),
+                )
+                for filename, expected in [
+                    (
+                        "missing_sourcemap.css",
+                        b"/*# sourceMappingURL=missing.css.map*/",
+                    ),
+                    ("missing_sourcemap.js", b"//# sourceMappingURL=missing.js.map"),
+                ]:
+                    relpath = self.hashed_file_path(filename)
+                    with storage.staticfiles_storage.open(relpath) as relfile:
+                        self.assertIn(expected, relfile.read())
+                self.assertPostCondition()
+
 
 @override_settings(
     STORAGES={
@@ -1698,6 +1785,43 @@ class TestEnhancedManifestStorageOptions(CollectionTestCase):
         self.assertEqual(
             len(original_css_files), 0, "Original CSS file should have been deleted"
         )
+
+    def test_sourcemap_strict_raises_on_missing_map(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with open(os.path.join(temp_dir, "missing_sourcemap.css"), "w") as f:
+                f.write(
+                    "* {outline: 1px solid red;}\n"
+                    "/*# sourceMappingURL=missing.css.map*/\n"
+                )
+            with open(os.path.join(temp_dir, "missing_sourcemap.js"), "w") as f:
+                f.write("//# sourceMappingURL=missing.js.map\nlet a_variable = 1;\n")
+            with override_settings(
+                STATICFILES_DIRS=[temp_dir],
+                STATICFILES_FINDERS=[
+                    "django.contrib.staticfiles.finders.FileSystemFinder"
+                ],
+                STORAGES={
+                    **settings.STORAGES,
+                    STATICFILES_STORAGE_ALIAS: {
+                        "BACKEND": (
+                            "django_manifeststaticfiles_enhanced.storage."
+                            "EnhancedManifestStaticFilesStorage"
+                        ),
+                        "OPTIONS": {
+                            "sourcemap_strict": True,
+                        },
+                    },
+                },
+            ):
+                finders.get_finder.cache_clear()
+                with self.assertRaises(CommandError) as cm:
+                    call_command(
+                        "collectstatic",
+                        interactive=False,
+                        verbosity=0,
+                        stderr=StringIO(),
+                    )
+                self.assertIsInstance(cm.exception.__cause__, ValueError)
 
 
 @override_settings(


### PR DESCRIPTION
When collectstatic finds a reference in a file to a missing file it will throw an error.
This is disruptive to the end user as there is a good chance some part of their site will not work, a missing background image or a missing file import in js/css.

However if the file that is missing is a sourcemap, it won't affect the running of their site but only the debugging of it. It won't affect the end users just the developer themselves. I've seen new users confused by the error when they include a third party package but have not downloaded the map file. They don't know about map files yet and will probably not be at the level where they are debugging their third party js libs. They want it to just work. Especially if the collectstatic was triggered by a deploy and it breaks their whole deploy process. 
Instead it could just be a warning.