### PR TITLE
Fixes #57 Account for whitespace/line endings after css sourceMappingUrl

### DIFF
--- a/django_manifeststaticfiles_enhanced/storage.py
+++ b/django_manifeststaticfiles_enhanced/storage.py
@@ -228,7 +228,7 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
                 (
                     (
                         r"(?m)^(?P<matched>/\*#[ \t]"
-                        r"(?-i:sourceMappingURL)=(?P<url>.*?)[ \t]*\*/)$"
+                        r"(?-i:sourceMappingURL)=(?P<url>.*?)[ \t]*\*/)\s*$"
                     ),
                     "/*# sourceMappingURL=%(url)s */",
                 ),


### PR DESCRIPTION
Matches js pattern for sourceMappingURL by adding `\s*` to catch trailing whitespace or windows CRLF line endings.