### PR TITLE
From edge case

### DIFF
--- a/django_manifeststaticfiles_enhanced/__init__.py
+++ b/django_manifeststaticfiles_enhanced/__init__.py
@@ -5,7 +5,7 @@ Enhanced ManifestStaticFilesStorage for Django with improvements from
 Django tickets: 27929, 21080, 26583, 28200, 34322, 23517
 """
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 from .storage import (
     EnhancedManifestStaticFilesStorage,

--- a/django_manifeststaticfiles_enhanced/jslex.py
+++ b/django_manifeststaticfiles_enhanced/jslex.py
@@ -498,10 +498,21 @@ def _extract_import_details(tokens, i, should_ignore_url):
     # import defaultExport, { export1, /* … */ } from "module-name";
     # import defaultExport, * as name from "module-name";
     else:
+        brace_depth = 0
         for j in range(i + 1, len(tokens)):
-            if tokens[j][0] == "punct" and tokens[j][1] == ";":
+            if tokens[j][0] == "punct" and tokens[j][1] == "{":
+                brace_depth += 1
+            elif tokens[j][0] == "punct" and tokens[j][1] == "}":
+                brace_depth -= 1
+            elif tokens[j][0] == "punct" and tokens[j][1] == ";":
                 return False
-            if tokens[j][0] == "id" and tokens[j][1] == "from" and j + 1 < len(tokens):
+            if (
+                brace_depth == 0
+                and tokens[j][0] == "id"
+                and tokens[j][1] == "from"
+                and (j == 0 or tokens[j - 1][1] != "as")
+                and j + 1 < len(tokens)
+            ):
                 return _format_match(tokens[j + 1], should_ignore_url)
     return False
 
@@ -518,7 +529,12 @@ def _extract_export_details(tokens, i, should_ignore_url):
         for j in range(i + 1, len(tokens)):
             if tokens[j][0] == "punct" and tokens[j][1] == ";":
                 return False
-            if tokens[j][0] == "id" and tokens[j][1] == "from" and j + 1 < len(tokens):
+            if (
+                tokens[j][0] == "id"
+                and tokens[j][1] == "from"
+                and (j == 0 or tokens[j - 1][1] != "as")
+                and j + 1 < len(tokens)
+            ):
                 return _format_match(tokens[j + 1], should_ignore_url)
 
     # export { name1, /* …, */ nameN } from "module-name";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-manifeststaticfiles-enhanced"
-version = "0.9.0"
+version = "0.9.1"
 description = "Enhanced ManifestStaticFilesStorage for Django"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/tests/staticfiles_tests/test_jslex.py
+++ b/tests/staticfiles_tests/test_jslex.py
@@ -638,7 +638,6 @@ class FindImportExportStringsTest(SimpleTestCase):
         self.assertEqual(imports[0][0], "./utils.js")
 
     def test_complex_import_patterns(self):
-        """Test complex import patterns."""
         js = """
         import defaultExport, { export1, export2 } from "module.js";
         import { export1 as alias1 } from "aliased.js";
@@ -652,3 +651,27 @@ class FindImportExportStringsTest(SimpleTestCase):
         self.assertIn("aliased.js", import_values)
         self.assertIn("namespace.js", import_values)
         self.assertIn("mixed.js", import_values)
+
+    def test_import_from_used_as_binding_name(self):
+        js = "import { from } from './from.js';"
+        imports = find_import_export_strings(js)
+        self.assertEqual(len(imports), 1)
+        self.assertEqual(imports[0][0], "./from.js")
+
+    def test_import_star_as_from_used_as_alias(self):
+        js = "import * as from from './from.js';"
+        imports = find_import_export_strings(js)
+        self.assertEqual(len(imports), 1)
+        self.assertEqual(imports[0][0], "./from.js")
+
+    def test_export_brace_from_used_as_binding_name(self):
+        js = "export { from } from './from.js';"
+        imports = find_import_export_strings(js)
+        self.assertEqual(len(imports), 1)
+        self.assertEqual(imports[0][0], "./from.js")
+
+    def test_export_star_as_from_used_as_alias(self):
+        js = "export * as from from './from.js';"
+        imports = find_import_export_strings(js)
+        self.assertEqual(len(imports), 1)
+        self.assertEqual(imports[0][0], "./from.js")


### PR DESCRIPTION
handle `import { from } from './from'`
It was looking for a url after the first from, not the second.