### PR TITLE
Update handling of build js files

### DIFF
--- a/django_manifeststaticfiles_enhanced/__init__.py
+++ b/django_manifeststaticfiles_enhanced/__init__.py
@@ -8,13 +8,19 @@ Django tickets: 27929, 21080, 26583, 28200, 34322, 23517
 __version__ = "0.9.1"
 
 from .storage import (
+    BuildArtifactWarning,
+    DynamicImportWarning,
     EnhancedManifestStaticFilesStorage,
+    ManifestStaticFilesWarning,
     SourcemapWarning,
     TestingManifestStaticFilesStorage,
 )
 
 __all__ = [
+    "BuildArtifactWarning",
+    "DynamicImportWarning",
     "EnhancedManifestStaticFilesStorage",
+    "ManifestStaticFilesWarning",
     "SourcemapWarning",
     "TestingManifestStaticFilesStorage",
 ]

--- a/django_manifeststaticfiles_enhanced/jslex.py
+++ b/django_manifeststaticfiles_enhanced/jslex.py
@@ -452,22 +452,27 @@ def find_import_export_strings(file_contents, should_ignore_url=None):
         if token_tuple[0] not in ["ws", "comment", "linecomment"]
     ]
     matches = []
+    warnings = []
 
     for i, (name, value, _) in enumerate(tokens):
         if name == "keyword" and value == "import":
-            import_details = _extract_import_details(tokens, i, should_ignore_url)
+            import_details = _extract_import_details(
+                tokens, i, should_ignore_url, warnings
+            )
             if import_details:
                 matches.append(import_details)
 
         elif name == "keyword" and value == "export":
-            export_details = _extract_export_details(tokens, i, should_ignore_url)
+            export_details = _extract_export_details(
+                tokens, i, should_ignore_url, warnings
+            )
             if export_details:
                 matches.append(export_details)
 
-    return matches
+    return matches, warnings
 
 
-def _extract_import_details(tokens, i, should_ignore_url):
+def _extract_import_details(tokens, i, should_ignore_url, warnings):
     # Check if this is actually a method name
     # (part of an object access) by looking at the previous token
     # if it's a . then this is a method name, not an import statement
@@ -482,12 +487,12 @@ def _extract_import_details(tokens, i, should_ignore_url):
     # check for plain import and function imports first
     # import "module-name";
     if i + 1 < len(tokens) and tokens[i + 1][0] == "string":
-        return _format_match(tokens[i + 1], should_ignore_url)
+        return _format_match(tokens[i + 1], should_ignore_url, warnings)
     # import("module-name");
     elif (
         i + 2 < len(tokens) and tokens[i + 1][0] == "punct" and tokens[i + 1][1] == "("
     ):
-        return _format_match(tokens[i + 2], should_ignore_url)
+        return _format_match(tokens[i + 2], should_ignore_url, warnings)
     # or we keep going till we see from
     # import { export1 } from "module-name";
     # import { export1 as alias1 } from "module-name";
@@ -513,11 +518,11 @@ def _extract_import_details(tokens, i, should_ignore_url):
                 and (j == 0 or tokens[j - 1][1] != "as")
                 and j + 1 < len(tokens)
             ):
-                return _format_match(tokens[j + 1], should_ignore_url)
+                return _format_match(tokens[j + 1], should_ignore_url, warnings)
     return False
 
 
-def _extract_export_details(tokens, i, should_ignore_url):
+def _extract_export_details(tokens, i, should_ignore_url, warnings):
     # export is used within modules as well as aggregation
     # we need to distinguish between them by looking for the from keyword
     # also from is an id not a reserved keyword
@@ -535,7 +540,7 @@ def _extract_export_details(tokens, i, should_ignore_url):
                 and (j == 0 or tokens[j - 1][1] != "as")
                 and j + 1 < len(tokens)
             ):
-                return _format_match(tokens[j + 1], should_ignore_url)
+                return _format_match(tokens[j + 1], should_ignore_url, warnings)
 
     # export { name1, /* …, */ nameN } from "module-name";
     # export { import1 as name1, /* …, */ nameN } from "module-name";
@@ -548,25 +553,25 @@ def _extract_export_details(tokens, i, should_ignore_url):
                 return False
             if tokens[j][0] == "punct" and tokens[j][1] == "}" and j + 2 < len(tokens):
                 if tokens[j + 1][0] == "id" and tokens[j + 1][1] == "from":
-                    return _format_match(tokens[j + 2], should_ignore_url)
+                    return _format_match(tokens[j + 2], should_ignore_url, warnings)
                 else:
                     return False
     return False
 
 
-def _format_match(token_tuple, should_ignore_url):
+def _format_match(token_tuple, should_ignore_url, warnings):
     # we can't support template strings with variables
     if token_tuple[1].startswith("`") and "${" in token_tuple[1]:
         url = token_tuple[1][1:-1].split("?")[0]
         if "${" in url:
             if should_ignore_url(url):
-                return
-            message = (
+                return None
+            warnings.append(
                 f"Found a template literal with a variable: {url} "
                 "Dynamic imports with template literals containing variables "
                 "are not supported as the actual import path cannot be "
                 "determined at build time."
             )
-            raise ValueError(message)
+            return None
     # the lex parser returns the string, with the wrapping quotes, remove them
     return (token_tuple[1][1:-1], token_tuple[2] + 1)

--- a/django_manifeststaticfiles_enhanced/management/commands/collectstatic.py
+++ b/django_manifeststaticfiles_enhanced/management/commands/collectstatic.py
@@ -15,7 +15,7 @@ from django.contrib.staticfiles.management.commands.collectstatic import (
 )
 from django.core.management.base import CommandError
 
-from django_manifeststaticfiles_enhanced.storage import SourcemapWarning
+from django_manifeststaticfiles_enhanced.storage import ManifestStaticFilesWarning
 
 # Global lock for directory creation in link operations
 _link_makedirs_lock = threading.Lock()
@@ -141,7 +141,7 @@ class Command(DjangoCollectstaticCommand):
         if self.post_process and hasattr(self.storage, "post_process"):
             processor = self.storage.post_process(found_files, dry_run=self.dry_run)
             for original_path, processed_path, processed in processor:
-                if isinstance(processed, SourcemapWarning):
+                if isinstance(processed, ManifestStaticFilesWarning):
                     self.log(str(processed), level=1)
                 elif isinstance(processed, Exception):
                     self.stderr.write("Post-processing '%s' failed!" % original_path)

--- a/django_manifeststaticfiles_enhanced/storage.py
+++ b/django_manifeststaticfiles_enhanced/storage.py
@@ -27,16 +27,16 @@ from django_manifeststaticfiles_enhanced.jslex import (
 _css_ignored_re = _lazy_re_compile(
     r"/\*.*?\*/"  # block comment
     r"|\\."  # escape sequence
-    r"|'(?:[^'\\]|\\.)*'"  # single-quoted string
-    r'|"(?:[^"\\]|\\.)*"',  # double-quoted string
+    r"|'(?:[^'\\\n]|\\.)*'"  # single-quoted string
+    r'|"(?:[^"\\\n]|\\.)*"',  # double-quoted string
     re.DOTALL,
 )
 _js_ignored_re = _lazy_re_compile(
     r"/\*.*?\*/"  # block comment
     r"|//[^\n]*"  # line comment
     r"|\\."  # escape sequence
-    r"|'(?:[^'\\]|\\.)*'"  # single-quoted string
-    r'|"(?:[^"\\]|\\.)*"'  # double-quoted string
+    r"|'(?:[^'\\\n]|\\.)*'"  # single-quoted string
+    r'|"(?:[^"\\\n]|\\.)*"'  # double-quoted string
     r"|`(?:[^`\\]|\\.)*`",  # template literal
     re.DOTALL,
 )
@@ -201,7 +201,19 @@ class StaticFileProcessingError(ValueError):
         self.file_name = file_name
 
 
-class SourcemapWarning(UserWarning):
+class ManifestStaticFilesWarning(UserWarning):
+    pass
+
+
+class SourcemapWarning(ManifestStaticFilesWarning):
+    pass
+
+
+class BuildArtifactWarning(ManifestStaticFilesWarning):
+    pass
+
+
+class DynamicImportWarning(ManifestStaticFilesWarning):
     pass
 
 
@@ -209,6 +221,24 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
 
     use_lexer = False
     sourcemap_strict = False
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Django's HashedFilesMixin.__init__ builds self._patterns as 2-tuples.
+        # Rebuild as 3-tuples (compiled, template, ignored_re) so each pattern
+        # carries its own ignore regex and call sites don't branch on file extension.
+        # JS patterns get _js_ignored_re; everything else gets _css_ignored_re.
+        self._patterns = {
+            extension: [
+                (
+                    compiled,
+                    template,
+                    _js_ignored_re if extension == "*.js" else _css_ignored_re,
+                )
+                for compiled, template in compiled_patterns
+            ]
+            for extension, compiled_patterns in self._patterns.items()
+        }
 
     # Override Django's base patterns to fix greedy .* in source map patterns.
     # The greedy .* captures trailing whitespace (tabs, spaces) into the url
@@ -253,56 +283,66 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
         (
             (
                 (
-                    r"""(?m)^\s*(?P<matched>(?-i:import)"""
-                    r"""(?P<import>[\s\{][^;]*?|\*\s*as\s*\w+)"""
-                    r"""\s*from\s*['"](?P<url>[./].*?)["']\s*;)"""
-                ),
-                """import%(import)s from "%(url)s";""",
-            ),
-            (
-                (
-                    r"""(?m)^\s*(?P<matched>(?-i:import)"""
+                    r"""(?:(?m:^)[ \t]*|(?<=[;{})])[ \t]*)"""
+                    r"""(?P<matched>(?-i:import)"""
                     r"""(?P<import>[\s\{][^;]*?|\*\s*as\s*\w+)"""
                     r"""\s*from\s*['"](?P<url>[./].*?)["']"""
-                    r"""\s*(?P<attributes>with\s*\{[^}]*\})\s*;)"""
+                    r"""(?P<attributes>(?:[ \t]*with\s*\{[^}]*\})?)"""
+                    r"""[ \t]*(?P<semi>;?))"""
                 ),
-                """import%(import)s from "%(url)s" %(attributes)s;""",
+                """import%(import)s from "%(url)s"%(attributes)s%(semi)s""",
             ),
             (
                 (
-                    r"""(?m)^\s*(?P<matched>(?-i:export)(?P<exports>[\s\{][^;]*?)"""
-                    r"""\s*from\s*["'](?P<url>[./].*?)["']\s*;)"""
-                ),
-                """export%(exports)s from "%(url)s";""",
-            ),
-            (
-                (
-                    r"""(?m)^\s*(?P<matched>(?-i:export)(?P<exports>[\s\{][^;]*?)"""
+                    r"""(?:(?m:^)[ \t]*|(?<=[;{})])[ \t]*)"""
+                    r"""(?P<matched>(?-i:export)(?P<exports>[\s\{][^;]*?)"""
                     r"""\s*from\s*["'](?P<url>[./].*?)["']"""
-                    r"""\s*(?P<attributes>with\s*\{[^}]*\})\s*;)"""
+                    r"""(?P<attributes>(?:[ \t]*with\s*\{[^}]*\})?)"""
+                    r"""[ \t]*(?P<semi>;?))"""
                 ),
-                """export%(exports)s from "%(url)s" %(attributes)s;""",
+                """export%(exports)s from "%(url)s"%(attributes)s%(semi)s""",
             ),
             (
-                r"""(?m)^\s*(?P<matched>import\s*['"](?P<url>[./].*?)["']\s*;)""",
-                """import"%(url)s";""",
+                (
+                    r"""(?:(?m:^)[ \t]*|(?<=[;{})])[ \t]*)"""
+                    r"""(?P<matched>(?-i:import)\s*['"]"""
+                    r"""(?P<url>[./].*?)["'][ \t]*(?P<semi>;?))"""
+                ),
+                """import"%(url)s"%(semi)s""",
             ),
             (
-                r"""(?P<matched>import\(["'](?P<url>.*?)["']\))""",
-                """import("%(url)s")""",
+                r"""(?P<matched>import\(["']"""
+                r"""(?P<url>[./][^"']*?)["'](?P<options>[^)]*)\))""",
+                """import("%(url)s"%(options)s)""",
             ),
         ),
     )
 
-    def get_ignored_blocks(self, content, for_js=False):
+    def get_ignored_blocks(self, content, ignored_re):
         """
         Return a sorted list of (start, end) tuples for content that should
-        be ignored during URL rewriting: block comments and string literals
-        for CSS, plus line comments (// ...) and template literals (`...`)
-        for JS.
+        be ignored during URL rewriting based on the specified pattern:
+        e.g. block comments and string literals for CSS, plus line comments
+        (// ...) and template literals (`...`) for JS.
         """
-        pattern = _js_ignored_re if for_js else _css_ignored_re
-        return [(m.start(), m.end()) for m in re.finditer(pattern, content)]
+        blocks = []
+        for m in re.finditer(ignored_re, content):
+            if self._is_midline_comment_on_long_line(content, m.start()):
+                continue
+            blocks.append((m.start(), m.end()))
+        return blocks
+
+    def _is_midline_comment_on_long_line(self, content, pos, threshold=500):
+        # Long lines are likely minified; mid-line // is probably a regex misparse.
+        if content[pos : pos + 2] != "//":
+            return False
+        line_start = content.rfind("\n", 0, pos) + 1
+        if not content[line_start:pos].strip():
+            return False
+        line_end = content.find("\n", pos)
+        if line_end == -1:
+            line_end = len(content)
+        return line_end - line_start > threshold
 
     def is_in_ignored_block(self, pos, ignored_blocks):
         for start, end in ignored_blocks:
@@ -331,12 +371,12 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
         If either of these are performed on a file, then that file is
         considered post-processed.
         """
-        self._sourcemap_warnings = []
+        self._post_process_warnings = []
         try:
             # if we're in dry run, still find urls and raise any exceptions
             if dry_run:
                 self._test_url_substitutions(paths)
-                for warn_name, warning in self._sourcemap_warnings:
+                for warn_name, warning in self._post_process_warnings:
                     yield warn_name, warn_name, warning
                 return
 
@@ -356,7 +396,10 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
             storage, path = paths[name]
             with storage.open(path) as f:
                 content = f.read().decode("utf-8")
+            file_is_js = os.path.splitext(name)[1] == ".js"
             for url, position, is_sourcemap in url_positions:
+                url_ext = os.path.splitext(urlsplit(urldefrag(url)[0]).path)[1]
+                url_is_js = url_ext in (".js", ".mjs")
                 try:
                     self._adjust_url(url, name, paths)
                 except ValueError as exc:
@@ -364,13 +407,25 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
                         pass
                     elif is_sourcemap and not self.sourcemap_strict:
                         line = _line_at_position(content, position)
-                        self._sourcemap_warnings.append(
+                        self._post_process_warnings.append(
                             (
                                 name,
                                 SourcemapWarning(
                                     f"{name!r}: sourcemap reference {url!r} "
-                                    "on line {line} "
+                                    f"on line {line} "
                                     "could not be resolved"
+                                ),
+                            )
+                        )
+                    elif file_is_js and not url_is_js:
+                        line = _line_at_position(content, position)
+                        self._post_process_warnings.append(
+                            (
+                                name,
+                                BuildArtifactWarning(
+                                    f"{name!r}: import {url!r} on line{line} "
+                                    "could not be resolved — this may be a "
+                                    "build artifact"
                                 ),
                             )
                         )
@@ -443,9 +498,9 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
             )
             hashed_files[self.hash_key(self.clean_name(name))] = hashed_name
             yield name, hashed_name, processed
-            for warn_name, warning in self._sourcemap_warnings:
+            for warn_name, warning in self._post_process_warnings:
                 yield warn_name, warn_name, warning
-            self._sourcemap_warnings.clear()
+            self._post_process_warnings.clear()
 
         # Phase 3: Handle circular dependencies
         if circular_deps:
@@ -455,9 +510,9 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
             for name, hashed_name in circular_hashes:
                 hashed_files[self.hash_key(self.clean_name(name))] = hashed_name
                 yield name, hashed_name, True
-            for warn_name, warning in self._sourcemap_warnings:
+            for warn_name, warning in self._post_process_warnings:
                 yield warn_name, warn_name, warning
-            self._sourcemap_warnings.clear()
+            self._post_process_warnings.clear()
 
         # Store the processed paths
         self.hashed_files.update(hashed_files)
@@ -590,24 +645,36 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
             if not self.import_export_pattern.search(content):
                 return url_positions
 
-            try:
-                urls = find_import_export_strings(
-                    content,
-                    should_ignore_url=lambda url: self._should_ignore_url(name, url),
+            urls, lex_warnings = find_import_export_strings(
+                content,
+                should_ignore_url=lambda url: self._should_ignore_url(name, url),
+            )
+            for msg in lex_warnings:
+                self._post_process_warnings.append(
+                    (
+                        name,
+                        DynamicImportWarning(f"'{name}': {msg}"),
+                    )
                 )
-            except ValueError as e:
-                message = e.args[0] if len(e.args) else ""
-                message = f"The js file '{name}' could not be processed.\n{message}"
-                raise StaticFileProcessingError(name) from ValueError(message)
             for url_name, position in urls:
+                if not url_name:
+                    continue
+                if (
+                    not url_name.startswith((".", "/"))
+                    and not re.match(r"^[a-z]+:", url_name)
+                    and not url_name.startswith("//")
+                ):
+                    # Bare module specifier (e.g. "react", "jquery") — the regex
+                    # path never matches these either, so silently skip them.
+                    continue
                 if self._should_adjust_url(url_name):
                     url_positions.append((url_name, position, False))
         else:
-            ignored_blocks = self.get_ignored_blocks(content, for_js=True)
             patterns = self._patterns.get("*.js", [])
-            if not any(p.search(content) for p, _ in patterns):
+            if not any(p.search(content) for p, *_ in patterns):
                 return url_positions
-            for pattern, _ in patterns:
+            for pattern, _, ignored_re in patterns:
+                ignored_blocks = self.get_ignored_blocks(content, ignored_re)
                 is_sourcemap = "sourceMappingURL" in pattern.pattern
                 for match in pattern.finditer(content):
                     if self.is_in_ignored_block(match.start(), ignored_blocks):
@@ -648,11 +715,11 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
                 if self._should_adjust_url(url_name):
                     url_positions.append((url_name, position, False))
         else:
-            ignored_blocks = self.get_ignored_blocks(content)
             patterns = self._patterns.get("*.css", [])
-            if not any(p.search(content) for p, _ in patterns):
+            if not any(p.search(content) for p, *_ in patterns):
                 return url_positions
-            for pattern, _ in patterns:
+            for pattern, _, ignored_re in patterns:
+                ignored_blocks = self.get_ignored_blocks(content, ignored_re)
                 is_sourcemap = "sourceMappingURL" in pattern.pattern
                 for match in pattern.finditer(content):
                     if self.is_in_ignored_block(match.start(), ignored_blocks):
@@ -834,10 +901,15 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
             key=lambda x: x[1],
         )
 
+        file_is_js = os.path.splitext(name)[1] == ".js"
+
         for url, pos, is_sourcemap in sorted_positions:
             position = pos
             # Add content before this URL
             result_parts.append(content[last_position:position])
+
+            url_ext = os.path.splitext(urlsplit(urldefrag(url)[0]).path)[1]
+            url_is_js = url_ext in (".js", ".mjs")
 
             try:
                 transformed_url = self._adjust_url(url, name, hashed_files)
@@ -846,12 +918,24 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
                     transformed_url = url
                 elif is_sourcemap and not self.sourcemap_strict:
                     line = _line_at_position(content, position)
-                    self._sourcemap_warnings.append(
+                    self._post_process_warnings.append(
                         (
                             name,
                             SourcemapWarning(
                                 f"{name!r}: sourcemap reference {url!r} on line {line} "
                                 "could not be resolved, leaving as-is"
+                            ),
+                        )
+                    )
+                    transformed_url = url
+                elif file_is_js and not url_is_js:
+                    line = _line_at_position(content, position)
+                    self._post_process_warnings.append(
+                        (
+                            name,
+                            BuildArtifactWarning(
+                                f"{name!r}: import {url!r} on line{line} "
+                                "could not be resolved — this may be a build artifact"
                             ),
                         )
                     )

--- a/django_manifeststaticfiles_enhanced/storage.py
+++ b/django_manifeststaticfiles_enhanced/storage.py
@@ -685,16 +685,21 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
 
         return url_positions
 
+    _STATMENT_BOUNDARY = r"(?:^|[;}]|\*/)"
+    _COMMENTS_AND_SPACE = r"(?:\s*(?://[^\n]*\n|/\*.*?\*/))*\s*"
+
     import_export_pattern = re.compile(
-        # check for import statements
-        r"((^|[;}]|\*/)\s*import\b|"
-        # check for dynamic imports
-        r"import\s\(|"
-        # check for edge case with comment in between import and opening bracket
-        r"import\s*/\*.*?\*/\s*\(|"
-        # check for the word export must be followed
-        r"\bexport[\s{/*])",
-        re.MULTILINE,
+        "|".join(
+            [
+                # static import at statement boundary
+                _STATMENT_BOUNDARY + r"\s*import\b",
+                # dynamic import(), optional comments before opening bracket
+                r"\bimport" + _COMMENTS_AND_SPACE + r"\(",
+                # export at statement boundary
+                _STATMENT_BOUNDARY + r"\s*export[\s{*/]",
+            ]
+        ),
+        re.MULTILINE | re.DOTALL,
     )
 
     def _process_css_urls(self, name, content):

--- a/tests/staticfiles_tests/project/documents/cached/css/ignored.css
+++ b/tests/staticfiles_tests/project/documents/cached/css/ignored.css
@@ -8,3 +8,11 @@ body {
     background: url();
 }
 
+body {
+    content: "url(non_exist.png)";
+    content: 'url(non_exist.png)';
+}
+
+/* Tailwind-style selector: \' escape must not start a false string */
+.tw\:bg-\[url\(\'non_exist.png\'\)\] { background: url(../img/relative.png); }
+body { font-family: 'sans-serif'; }

--- a/tests/staticfiles_tests/project/documents/cached/lexer_only.js
+++ b/tests/staticfiles_tests/project/documents/cached/lexer_only.js
@@ -1,0 +1,13 @@
+import(
+    "./module.js"
+);
+import(/*comment*/"./module.js");
+
+import /*comment*/ "./module.js";
+import { lexerOnlyConst } from /*comment*/ "./module.js";
+
+const re1 = /test"pattern/; import("./module.js");
+const re2 = /[a-z//]/; import("./module.js");
+
+const re3 = /test`pattern/;
+import(`./module.js`);

--- a/tests/staticfiles_tests/project/documents/cached/module.js
+++ b/tests/staticfiles_tests/project/documents/cached/module.js
@@ -15,10 +15,11 @@ import {
 } from "./module_test.js";
 import relativeModule from "../nested/js/nested.js";
 
-// Dynamic imports.
+// Dynamic imports with import attributes (second argument).
 const dynamicModule = import("./module_test.js");
 const dynamicModule = import('./module_test.js');
 const dynamicModule = import(`./module_test.js`);
+const dynamicModule = import("./module_test.js", { with: { type: "json" } });
 
 // import using the with attribute
 import k from"./other.css"with{type:"css"};
@@ -37,6 +38,38 @@ export {
     secondVar as secondVarAlias
 } from "./module_test.js";
 
+
+// Mid-line import (after other code on the same line, as seen in minified output).
+var placeholder; import { testConst as alias2 } from "./module_test.js";
+// Multiple imports on one minified line.
+import{testConst as alias3}from"./module_test.js";import relativeModule2 from"../nested/js/nested.js";
+// ASI: no trailing semicolon.
+import{testConst as alias4}from"./module_test.js"
+
+// ASI: spaced form without trailing semicolon.
+import * as mAsi from "./module_test.js"
+import { testConst as aliasAsi } from "./module_test.js"
+
+// Imports inside string literals should be ignored.
+const msgStr = 'import { foo } from "./module_test_missing.js";';
+const helpStr = "import { bar } from './module_test_missing.js';";
+const tmplLit = `import { baz } from "./module_test_missing.js";`;
+const dynStr = 'const x = import("./module_test_missing.js");';
+const multiLineLit = `
+import { baz } from "./module_test_missing.js";
+`;
+
+// Export without from must not consume a subsequent import's from clause.
+export { testConst };
+import { firstConst } from "./module_test.js";
+
+// Imports in JSDoc block comments after a real import (regression: cross-boundary match).
+import '../nested/js/nested.js';
+/**
+ * @example
+ * import { something } from "./module_test_missing.js";
+ */
+function jsdocExample() {}
 
 // These should not be processed
 // @returns {import("./non-existent-1").something}

--- a/tests/staticfiles_tests/test_jslex.py
+++ b/tests/staticfiles_tests/test_jslex.py
@@ -497,49 +497,49 @@ class FindImportExportStringsTest(SimpleTestCase):
     def test_import_statement_simple(self):
         """Test simple import statement."""
         js = 'import "module.js";'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "module.js")
 
     def test_import_statement_from(self):
         """Test import with from clause."""
         js = 'import { func } from "module.js";'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "module.js")
 
     def test_import_statement_default(self):
         """Test default import."""
         js = 'import React from "react.js";'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "react.js")
 
     def test_import_dynamic(self):
         """Test dynamic import."""
         js = 'import("module.js").then(m => m.default);'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "module.js")
 
     def test_export_from(self):
         """Test export from statement."""
         js = 'export { func } from "module.js";'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "module.js")
 
     def test_export_star_from(self):
         """Test export * from statement."""
         js = 'export * from "module.js";'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "module.js")
 
     def test_export_star_as_from(self):
         """Test export * as from statement."""
         js = 'export * as utils from "utils.js";'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "utils.js")
 
@@ -551,7 +551,7 @@ class FindImportExportStringsTest(SimpleTestCase):
         import utils from "./utils.js";
         export { helper } from "./helper.js";
         """
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 4)
         import_values = [imp[0] for imp in imports]
         self.assertIn("react.js", import_values)
@@ -562,16 +562,16 @@ class FindImportExportStringsTest(SimpleTestCase):
     def test_export_without_from(self):
         """Test export without from (should not be captured)."""
         js = "export const value = 42;"
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 0)
         js = 'export const value = 42; export { helper } from "./helper.js";'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         js = 'export { variable }; export { helper } from "./helper.js";'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         js = 'export { variable }\n export { helper } from "./helper.js";'
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
 
     def test_import_with_comments(self):
@@ -586,7 +586,7 @@ class FindImportExportStringsTest(SimpleTestCase):
         import { Component } from /* "oldreact.js" */ "react.js";
         import(/* "oldreact.js" */ "react.js")
         """
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 4)
         import_values = [imp[0] for imp in imports]
         self.assertEqual(import_values.count("react.js"), 4)
@@ -601,7 +601,7 @@ class FindImportExportStringsTest(SimpleTestCase):
         */
         import { Component } from /* "oldmodule.js" */ "module.js";
         """
-        exports = find_import_export_strings(js)
+        exports, _ = find_import_export_strings(js)
         self.assertEqual(len(exports), 2)
         export_values = [imp[0] for imp in exports]
         self.assertEqual(export_values.count("module.js"), 2)
@@ -614,7 +614,7 @@ class FindImportExportStringsTest(SimpleTestCase):
             return x * 2;
         }
         """
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 0)
 
     def test_poor_syntax(self):
@@ -623,7 +623,7 @@ class FindImportExportStringsTest(SimpleTestCase):
         import utils for "./utils.js";
         export *;
         """
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 0)
 
     def test_template_literal_with_import_like_content(self):
@@ -632,7 +632,7 @@ class FindImportExportStringsTest(SimpleTestCase):
         const code = `import React from "react";`;
         import utils from "./utils.js";
         """
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         # Should only capture the actual import, not the template literal content
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "./utils.js")
@@ -644,7 +644,7 @@ class FindImportExportStringsTest(SimpleTestCase):
         import * as name from "namespace.js";
         import defaultExport, * as name from "mixed.js";
         """
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 4)
         import_values = [imp[0] for imp in imports]
         self.assertIn("module.js", import_values)
@@ -654,24 +654,24 @@ class FindImportExportStringsTest(SimpleTestCase):
 
     def test_import_from_used_as_binding_name(self):
         js = "import { from } from './from.js';"
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "./from.js")
 
     def test_import_star_as_from_used_as_alias(self):
         js = "import * as from from './from.js';"
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "./from.js")
 
     def test_export_brace_from_used_as_binding_name(self):
         js = "export { from } from './from.js';"
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "./from.js")
 
     def test_export_star_as_from_used_as_alias(self):
         js = "export * as from from './from.js';"
-        imports = find_import_export_strings(js)
+        imports, _ = find_import_export_strings(js)
         self.assertEqual(len(imports), 1)
         self.assertEqual(imports[0][0], "./from.js")

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -1134,6 +1134,161 @@ class TestCollectionJSModuleImportAggregationManifestStorage(
             self.assertIn(b'import Button from "./Button";', content)
             self.assertIn(b'import Base from "./something.base";', content)
 
+    def test_lexer_only_patterns(self):
+        relpath = self.hashed_file_path("cached/lexer_only.js")
+        with storage.staticfiles_storage.open(relpath) as f:
+            content = f.read()
+        # Multiline import is NOT rewritten (pattern requires quote right after `(`).
+        self.assertIn(b'import(\n    "./module.js"\n)', content)
+        # Block comment inside dynamic import is NOT rewritten.
+        self.assertIn(b'import(/*comment*/"./module.js")', content)
+        # Block comment in side-effect import is NOT rewritten.
+        self.assertIn(b'import /*comment*/ "./module.js"', content)
+        # Block comment between from and URL is NOT rewritten.
+        self.assertIn(b'from /*comment*/ "./module.js"', content)
+        # Same-line string runon: import after /test"pattern/ is NOT rewritten.
+        self.assertIn(
+            b'const re1 = /test"pattern/; import("./module.js")',
+            content,
+        )
+        # Same-line line comment runon: import after /[a-z//]/ is NOT rewritten.
+        self.assertIn(
+            b'const re2 = /[a-z//]/; import("./module.js")',
+            content,
+        )
+        # Import after regex literal with backtick is NOT rewritten.
+        self.assertIn(
+            b"const re3 = /test`pattern/;\nimport(`./module.js`)",
+            content,
+        )
+
+
+class TestImportExportPattern(unittest.TestCase):
+    """Unit tests for the import_export_pattern pre-filter regex.
+
+    This pattern is a fast gate before the expensive lexer. False positives
+    (matching when there is no real import/export) are acceptable — they just
+    cause an unnecessary lexer run. False negatives (not matching when there
+    IS a real import/export) are bugs: the lexer never runs and URLs are not
+    rewritten.
+    """
+
+    pattern = EnhancedManifestStaticFilesStorage.import_export_pattern
+
+    def assertMatches(self, content):
+        self.assertIsNotNone(
+            self.pattern.search(content),
+            f"Expected pattern to match: {content!r}",
+        )
+
+    def assertNoMatch(self, content):
+        self.assertIsNone(
+            self.pattern.search(content),
+            f"Expected pattern NOT to match: {content!r}",
+        )
+
+    # --- static imports ---
+
+    def test_static_import_start_of_line(self):
+        self.assertMatches("import foo from './module.js'")
+
+    def test_static_import_indented(self):
+        self.assertMatches("    import foo from './module.js'")
+
+    def test_static_import_after_semicolon(self):
+        # minified: }import or ;import
+        self.assertMatches(";import foo from './module.js'")
+
+    def test_static_import_after_brace(self):
+        self.assertMatches("}import foo from './module.js'")
+
+    def test_static_import_after_block_comment(self):
+        # e.g. a licence banner ending with */
+        self.assertMatches("/* licence */\nimport foo from './module.js'")
+
+    # --- dynamic imports ---
+
+    def test_dynamic_import_basic(self):
+        self.assertMatches("import('./module.js')")
+
+    def test_dynamic_import_with_space(self):
+        self.assertMatches("import ('./module.js')")
+
+    def test_dynamic_import_mid_expression(self):
+        # not at a statement boundary — only branch 2 can catch this
+        self.assertMatches("const load = () => import('./module.js')")
+
+    def test_dynamic_import_line_comment(self):
+        self.assertMatches("import // comment\n('./module.js')")
+
+    def test_dynamic_import_block_comment(self):
+        self.assertMatches("import /* comment */ ('./module.js')")
+
+    def test_dynamic_import_multiline_block_comment(self):
+        self.assertMatches("import /* comment\n   spanning lines */ ('./module.js')")
+
+    def test_dynamic_import_multiple_line_comments(self):
+        self.assertMatches("import // first\n// second\n('./module.js')")
+
+    def test_dynamic_import_mixed_comments(self):
+        self.assertMatches("import // c1\n/* c2 */\n// c3\n    ('./module.js')")
+
+    def test_dynamic_import_mid_expression_with_line_comment(self):
+        # the key correctness case: not at a statement boundary, has a line
+        # comment — only the dynamic import branch catches this
+        self.assertMatches("const load = () => import // comment\n('./module.js')")
+
+    # --- exports ---
+
+    def test_export_default(self):
+        self.assertMatches("export default foo")
+
+    def test_export_named(self):
+        self.assertMatches("export { foo, bar }")
+
+    def test_export_star(self):
+        self.assertMatches("export * from './module.js'")
+
+    def test_export_star_minified(self):
+        # no space between export and * in minified output
+        self.assertMatches("export*from './module.js'")
+
+    def test_export_after_semicolon(self):
+        self.assertMatches(";export default foo")
+
+    def test_export_after_brace(self):
+        self.assertMatches("}export default foo")
+
+    # --- should NOT match ---
+
+    def test_no_match_important(self):
+        # 'import' embedded in a longer word
+        self.assertNoMatch("important rule")
+
+    def test_no_match_exports(self):
+        # CommonJS exports object — 's' is a word character, no boundary
+        self.assertNoMatch("exports.foo = 1")
+
+    def test_no_match_export_identifier(self):
+        self.assertNoMatch("exportSomething()")
+
+    def test_no_match_reimport(self):
+        # no word boundary before 'import'
+        self.assertNoMatch("reimport('./module.js')")
+
+    def test_no_match_import_in_line_comment(self):
+        # '//' is not a statement boundary, so the static branch misses it;
+        # 'import' is not followed by '(' so the dynamic branch misses it too
+        self.assertNoMatch("// import foo from './module.js'")
+
+    def test_no_match_export_in_line_comment(self):
+        # statement boundary check on export rules this out; the old
+        # \bexport[\s{/*] pattern would have matched this
+        self.assertNoMatch("// export default foo")
+
+    def test_no_match_export_in_block_comment(self):
+        self.assertNoMatch("/* export default foo */")
+
 
 @override_settings(
     STORAGES={
@@ -1245,6 +1400,34 @@ class TestCollectionJSModuleImportAggregationManifestStorageLexer(
                 f'import Component from "./{module_test_hashed}";'.encode(),
                 content,
             )
+
+    def test_lexer_only_patterns(self):
+        relpath = self.hashed_file_path("cached/lexer_only.js")
+        with storage.staticfiles_storage.open(relpath) as f:
+            content = f.read()
+        # Multiline import IS rewritten (lexer handles whitespace between `(` and URL).
+        self.assertIn(b'import(\n    "./module.5c82f2259163.js"\n)', content)
+        # Block comment inside dynamic import IS rewritten.
+        self.assertIn(b'import(/*comment*/"./module.5c82f2259163.js")', content)
+        # Block comment in side-effect import IS rewritten.
+        self.assertIn(b'import /*comment*/ "./module.5c82f2259163.js"', content)
+        # Block comment between from and URL IS rewritten.
+        self.assertIn(b'from /*comment*/ "./module.5c82f2259163.js"', content)
+        # Same-line string runon: import after /test"pattern/ IS rewritten.
+        self.assertIn(
+            b'const re1 = /test"pattern/; import("./module.5c82f2259163.js")',
+            content,
+        )
+        # Same-line line comment runon: import after /[a-z//]/ IS rewritten.
+        self.assertIn(
+            b'const re2 = /[a-z//]/; import("./module.5c82f2259163.js")',
+            content,
+        )
+        # Import after regex literal IS rewritten (lexer handles regex literals).
+        self.assertIn(
+            b"const re3 = /test`pattern/;\nimport(`./module.5c82f2259163.js`)",
+            content,
+        )
 
 
 class CustomExtractorStorage(EnhancedManifestStaticFilesStorage):

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -89,7 +89,7 @@ class TestHashedFiles:
 
     def test_path_ignored_completely(self):
         relpath = self.hashed_file_path("cached/css/ignored.css")
-        self.assertEqual(relpath, "cached/css/ignored.55e7c226dda1.css")
+        self.assertEqual(relpath, "cached/css/ignored.1dd606c55744.css")
         with storage.staticfiles_storage.open(relpath) as relfile:
             content = relfile.read()
             self.assertIn(b"#foobar", content)
@@ -99,6 +99,16 @@ class TestHashedFiles:
             self.assertIn(b"chrome:foobar", content)
             self.assertIn(b"//foobar", content)
             self.assertIn(b"url()", content)
+            # URLs inside string literals are ignored.
+            self.assertIn(b'content: "url(non_exist.png)";', content)
+            self.assertIn(b"content: 'url(non_exist.png)';", content)
+            # Tailwind-style \' escape sequences must not start a false string
+            # that shadows the real url() on the same line.
+            self.assertIn(
+                rb".tw\:bg-\[url\(\'non_exist.png\'\)\]"
+                rb" { background: url(../img/relative.acae32e4532b.png); }",
+                content,
+            )
         self.assertPostCondition()
 
     def test_path_with_querystring(self):
@@ -922,6 +932,9 @@ class JSModuleImportAggregationTestMixin:
             # Dynamic imports (single/double quotes — processed by both paths).
             b'const dynamicModule = import("./module_test.477bbebe77f0.js");',
             b"const dynamicModule = import('./module_test.477bbebe77f0.js');",
+            # Dynamic import with import attributes (second argument preserved).
+            b'const dynamicModule = import("./module_test.477bbebe77f0.js", '
+            b'{ with: { type: "json" } });',
             # Creating a module object.
             b'import * as NewModule from "./module_test.477bbebe77f0.js";',
             # Creating a minified module object.
@@ -937,6 +950,31 @@ class JSModuleImportAggregationTestMixin:
             b'} from "./module_test.477bbebe77f0.js";',
             # With attribute (import assertions).
             b'import k from"./other.d41d8cd98f00.css"with{type:"css"};',
+            # Mid-line import (after other code on the same line).
+            b"var placeholder; "
+            b'import { testConst as alias2 } from "./module_test.477bbebe77f0.js";',
+            # Multiple imports packed onto one minified line.
+            b'import{testConst as alias3}from"./module_test.477bbebe77f0.js";'
+            b'import relativeModule2 from"../nested/js/nested.866475c46bb4.js";',
+            # ASI: no trailing semicolon — structure preserved, only URL replaced.
+            b'import{testConst as alias4}from"./module_test.477bbebe77f0.js"',
+            # ASI: spaced form without trailing semicolon.
+            b'import * as mAsi from "./module_test.477bbebe77f0.js"\n',
+            b'import { testConst as aliasAsi } from "./module_test.477bbebe77f0.js"\n',
+            # Imports inside string literals are ignored.
+            b"""const msgStr = 'import { foo } from "./module_test_missing.js";';""",
+            b"""const helpStr = "import { bar } from './module_test_missing.js';";""",
+            b"""const tmplLit = `import { baz } from "./module_test_missing.js";`;""",
+            b"""const dynStr = 'const x = import("./module_test_missing.js");';""",
+            b"const multiLineLit = `\n"
+            b'import { baz } from "./module_test_missing.js";\n'
+            b"`;",
+            # Export without from must not consume a subsequent import's from clause.
+            b"export { testConst };",
+            b'import { firstConst } from "./module_test.477bbebe77f0.js";',
+            # Import in JSDoc block comment after a real import is left alone.
+            b"import '../nested/js/nested.866475c46bb4.js';",
+            b'import { something } from "./module_test_missing.js";',
             # Unprocessed: comments and string literals (ignored by both paths).
             b'// @returns {import("./non-existent-1").something}',
             b'/* @returns {import("./non-existent-2").something} */',
@@ -1011,12 +1049,12 @@ class TestCollectionJSModuleImportAggregationManifestStorage(
         relpath = self.hashed_file_path("cached/module.js")
         # Hash differs from the lexer path because the backtick import is not
         # processed, leaving the URL unhashed.
-        self.assertNotEqual(relpath, "cached/module.7a0f6282224e.js")
+        self.assertNotEqual(relpath, "cached/module.97c98e519035.js")
         super().test_module_import()
 
     def test_aggregating_modules(self):
         relpath = self.hashed_file_path("cached/module.js")
-        self.assertNotEqual(relpath, "cached/module.7a0f6282224e.js")
+        self.assertNotEqual(relpath, "cached/module.97c98e519035.js")
         super().test_aggregating_modules()
 
     def test_template_literal_not_processed(self):
@@ -1042,6 +1080,59 @@ class TestCollectionJSModuleImportAggregationManifestStorage(
             with storage.staticfiles_storage.open(relpath) as relfile:
                 content = relfile.read()
                 self.assertIn(b"./${module_name}", content)
+
+    def test_build_artifact_regex_path(self):
+        """
+        With the regex path, bare module specifiers (e.g. "react") are invisible
+        to the pattern matcher (patterns require a ./ or / prefix), so the
+        relative import is still rewritten normally.
+
+        Extensionless imports (e.g. "./Button") that can't be resolved emit a
+        BuildArtifactWarning and are left unchanged, but processing of the rest
+        of the file continues.
+        """
+        file_contents = {
+            "build_artifact.js": (
+                'import React from "react";\n'
+                'import Component from "./module_test.js";\n'
+                'import Button from "./Button";\n'
+                'import Base from "./something.base";\n'
+                "export default Component;\n"
+            ),
+            "module_test.js": "export {};\n",
+        }
+        for filename, content in file_contents.items():
+            with open(self._get_filename_path(filename), "w") as f:
+                f.write(content)
+
+        with self.modify_settings(STATICFILES_DIRS={"append": self._temp_dir}):
+            finders.get_finder.cache_clear()
+            out = StringIO()
+            call_command("collectstatic", interactive=False, verbosity=1, stdout=out)
+
+            # Non-JS imports trigger a BuildArtifactWarning (extensionless or
+            # non-.js/.mjs extension both warn; only a missing .js/.mjs errors).
+            self.assertIn("build artifact", out.getvalue())
+            self.assertIn("./Button", out.getvalue())
+            self.assertIn("./something.base", out.getvalue())
+
+            module_test_hashed = os.path.basename(
+                self.hashed_file_path("test/module_test.js")
+            )
+            relpath = self.hashed_file_path("test/build_artifact.js")
+            with storage.staticfiles_storage.open(relpath) as relfile:
+                content = relfile.read()
+
+            # Bare specifier unchanged (pattern never matched it).
+            self.assertIn(b'import React from "react";', content)
+            # Relative import with extension IS rewritten.
+            self.assertIn(
+                f'import Component from "./{module_test_hashed}";'.encode(),
+                content,
+            )
+            # Non-JS imports are left unchanged (warned, not errored).
+            self.assertIn(b'import Button from "./Button";', content)
+            self.assertIn(b'import Base from "./something.base";', content)
 
 
 @override_settings(
@@ -1073,17 +1164,16 @@ class TestCollectionJSModuleImportAggregationManifestStorageLexer(
 
     def test_module_import(self):
         relpath = self.hashed_file_path("cached/module.js")
-        self.assertEqual(relpath, "cached/module.7a0f6282224e.js")
+        self.assertEqual(relpath, "cached/module.5c82f2259163.js")
         super().test_module_import()
 
     def test_aggregating_modules(self):
         relpath = self.hashed_file_path("cached/module.js")
-        self.assertEqual(relpath, "cached/module.7a0f6282224e.js")
+        self.assertEqual(relpath, "cached/module.5c82f2259163.js")
         super().test_aggregating_modules()
 
     def test_template_literal_with_variables(self):
-        """Test that template literals with variables raise an appropriate error."""
-        # Create initial static files.
+        """Test that template literals with variables in the path are warned about."""
         file_contents = (
             ("dynamic_import.js", "import(`./${module_name}`);"),
             ("module.js", "this"),
@@ -1095,50 +1185,66 @@ class TestCollectionJSModuleImportAggregationManifestStorageLexer(
         with self.modify_settings(STATICFILES_DIRS={"append": self._temp_dir}):
             finders.get_finder.cache_clear()
             err = StringIO()
-            # Expect ValueError with message about template literals
-            error_message = "Found a template literal with a variable: ./${module_name}"
 
-            with self.assertRaisesMessage(CommandError, error_message):
-                call_command(
-                    "collectstatic", interactive=False, verbosity=0, stderr=err
-                )
+            # Template literals with variables in the path are now a warning,
+            # not a hard error — collectstatic completes successfully.
+            call_command("collectstatic", interactive=False, verbosity=0, stderr=err)
+            relpath = self.hashed_file_path("test/dynamic_import.js")
+            with storage.staticfiles_storage.open(relpath) as relfile:
+                content = relfile.read()
+                # The unresolvable import is left unchanged.
+                self.assertIn(b"./${module_name}", content)
 
-            if django.VERSION[:2] not in [(4, 2), (5, 0)]:
-                with override_settings(
-                    STORAGES={
-                        **settings.STORAGES,
-                        STATICFILES_STORAGE_ALIAS: {
-                            "BACKEND": (
-                                "django_manifeststaticfiles_enhanced.storage."
-                                "EnhancedManifestStaticFilesStorage"
-                            ),
-                            "OPTIONS": {
-                                "ignore_errors": [
-                                    "test/dynamic_import.js:./${module_name}"
-                                ],
-                            },
-                        },
-                    }
-                ):
-                    call_command(
-                        "collectstatic", interactive=False, verbosity=0, stderr=err
-                    )
-                    relpath = self.hashed_file_path("test/dynamic_import.js")
-                    with storage.staticfiles_storage.open(relpath) as relfile:
-                        content = relfile.read()
-                        self.assertIn(b"./${module_name}", content)
-
-            # Change the contents of the dynamic_import file.
-            # variables in the querystring are okay
+            # Variables in the query string only are fine — the base URL is replaced.
             with open(self._get_filename_path("dynamic_import.js"), "w+b") as f:
-                f.write(b"import(`module.js?t=${Date.now()}`);")
+                f.write(b"import(`./module.js?t=${Date.now()}`);")
 
-            # a second collectstatic.
             call_command("collectstatic", interactive=False, verbosity=0, stderr=err)
             relpath = self.hashed_file_path("test/dynamic_import.js")
             with storage.staticfiles_storage.open(relpath) as relfile:
                 content = relfile.read()
                 self.assertIn(b"module.9e925e9341b4.js", content)
+
+    def test_build_artifact_lexer_path(self):
+        """
+        With the lexer path, bare module specifiers (e.g. "react") are silently
+        skipped — no warning, consistent with the regex path which never matches
+        them. Relative imports in the same file are still rewritten.
+        """
+        file_contents = {
+            "build_artifact.js": (
+                'import React from "react";\n'
+                'import Component from "./module_test.js";\n'
+                "export default Component;\n"
+            ),
+            "module_test.js": "export {};\n",
+        }
+        for filename, content in file_contents.items():
+            with open(self._get_filename_path(filename), "w") as f:
+                f.write(content)
+
+        with self.modify_settings(STATICFILES_DIRS={"append": self._temp_dir}):
+            finders.get_finder.cache_clear()
+            out = StringIO()
+            call_command("collectstatic", interactive=False, verbosity=1, stdout=out)
+
+            # No warning for bare specifiers.
+            self.assertNotIn("react", out.getvalue())
+
+            module_test_hashed = os.path.basename(
+                self.hashed_file_path("test/module_test.js")
+            )
+            relpath = self.hashed_file_path("test/build_artifact.js")
+            with storage.staticfiles_storage.open(relpath) as relfile:
+                content = relfile.read()
+
+            # Bare specifier unchanged.
+            self.assertIn(b'import React from "react";', content)
+            # Relative import IS rewritten — only the bare specifier was skipped.
+            self.assertIn(
+                f'import Component from "./{module_test_hashed}";'.encode(),
+                content,
+            )
 
 
 class CustomExtractorStorage(EnhancedManifestStaticFilesStorage):


### PR DESCRIPTION
The lexer was not handling bare imports correctly. It was trying to replace `import * from jquery`, which is not something collectstatic can ever replace, it is most likely a build script that has ended up in source or the user is using an importmap, either way it would be nice to ignore it.

This branch emits a warning similar to SourcemapWarning so the processing can continue on these files.

There are also some fixes from review of https://github.com/django/django/pull/20942 added too.