### PR TITLE
Option to ignore processing of JS bundlers like Vite, webpack, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,69 @@ Also available:
  - manifest_name: change the name of the staticfiles.json file
 
 
+#### Skip files already hashed by a bundler (`prehashed`)
+
+JS bundlers (Vite, webpack, rollup, esbuild, etc) add their own cache busting
+filenames, e.g. `dist/assets/app.4889e940.js`. When those land
+in your static dir, `collectstatic` would hash them again
+(`app.4889e940.a1b2c3d4.js`). Worse still, with `keep_original_files=False`
+it can delete the chunked files the bundler actually references in production.
+
+This option allows you to skip processing of those files and add them to the
+manifest as their own name. It's up to you to provide a callable
+(or a `"dotted.path.to_callable"`) that receives a file name and returns `True`
+when that file already has a cache busting filename:
+
+```python
+# settings.py
+STORAGES = {
+    "staticfiles": {
+        "BACKEND": "django_manifeststaticfiles_enhanced.storage.EnhancedManifestStaticFilesStorage",
+        "OPTIONS": {
+            "prehashed": "myapp.staticfiles.is_vite_output",
+        },
+    },
+}
+```
+
+A callable might just match a naming convention:
+
+```python
+# myapp/staticfiles.py
+import re
+
+_BUNDLER_HASH = re.compile(r"\.[0-9a-f]{8,}\.[a-z0-9]+$")
+
+def is_vite_output(name):
+    return name.startswith("dist/") and bool(_BUNDLER_HASH.search(name))
+```
+
+For a definitive answer, you could read the bundler's own output manifest.
+The callable below reads Vite's `manifest.json` to get a definitive answer.
+It uses the cached set as the callable will be used for each static file.
+
+```python
+# myapp/staticfiles.py
+import json
+from functools import lru_cache
+
+@lru_cache(maxsize=1)
+def _vite_outputs():
+    # Vite's manifest lists every emitted file under "file"/"css"/"assets".
+    with open("frontend/dist/.vite/manifest.json") as f:
+        manifest = json.load(f)
+    outputs = set()
+    for entry in manifest.values():
+        if "file" in entry:
+            outputs.add("dist/" + entry["file"])
+        outputs.update("dist/" + p for p in entry.get("css", []))
+        outputs.update("dist/" + p for p in entry.get("assets", []))
+    return outputs
+
+def is_vite_output(name):
+    return name.replace("\\", "/") in _vite_outputs()
+```
+
 ### --parallel command line option
 By default the copying of files to the static folder uses 10 threads, this should be optimal for most projects but you can supply the --parallel option to add more workers if you have lots of files and fast io, or less workers if you have few files and slow io (NAS). Set --parallel to 1 to disable parallel collection.
 
@@ -287,6 +350,10 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 This project is licensed under the BSD 3-Clause License - the same license as Django.
 
 ## Changelog
+
+### 0.10.0
+
+ - Option to ignore processing of JS bundlers like Vite, webpack, etc.
 
 ### 0.9.0
 

--- a/django_manifeststaticfiles_enhanced/__init__.py
+++ b/django_manifeststaticfiles_enhanced/__init__.py
@@ -5,7 +5,7 @@ Enhanced ManifestStaticFilesStorage for Django with improvements from
 Django tickets: 27929, 21080, 26583, 28200, 34322, 23517
 """
 
-__version__ = "0.9.1"
+__version__ = "0.10.0"
 
 from .storage import (
     BuildArtifactWarning,

--- a/django_manifeststaticfiles_enhanced/storage.py
+++ b/django_manifeststaticfiles_enhanced/storage.py
@@ -237,6 +237,8 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
     use_lexer = False
     sourcemap_strict = False
     ignore_errors = []
+    prehashed = None
+    _prehashed = frozenset()
 
     def __init__(self, *args, **kwargs):
         if django.VERSION >= (6, 1):
@@ -388,6 +390,34 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
             if pos < start:
                 return False
         return False
+
+    def _prehashed_checker(self):
+        """Resolve and memoize the ``prehashed`` callable (or ``None``)."""
+        if "_prehashed_checker_cache" not in self.__dict__:
+            checker = self.prehashed
+            if isinstance(checker, str):
+                from django.utils.module_loading import import_string
+
+                checker = import_string(checker)
+            if checker is not None and not callable(checker):
+                raise ImproperlyConfigured(
+                    "prehashed must be a callable or a dotted path to one"
+                )
+            self.__dict__["_prehashed_checker_cache"] = checker
+        return self.__dict__["_prehashed_checker_cache"]
+
+    def is_prehashed(self, name):
+        """
+        Return True if ``name`` already carries a content hash from a build tool
+        and must be passed through untouched: not re-hashed, its internal
+        references not rewritten, and registered in the manifest under its own
+        (unchanged) name.
+
+        The default implementation consults the configured ``prehashed``
+        callable.
+        """
+        checker = self._prehashed_checker()
+        return False if checker is None else bool(checker(name))
 
     def url(self, name, force=False):
         if settings.DEBUG and not force:
@@ -587,8 +617,12 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
         list of file names that need substituting along with the position in
         the file.
         """
+        self._prehashed = frozenset(n for n in paths if self.is_prehashed(n))
+
         substitutions_dict = {}
         for name in paths:
+            if name in self._prehashed:
+                continue
             finders = self._get_url_finders(name)
             if not finders:
                 continue
@@ -895,7 +929,12 @@ class EnhancedHashedFilesMixin(DebugValidationMixin, HashedFilesMixin):
             if hasattr(original_file, "seek"):
                 original_file.seek(0)
 
-            hashed_name = self.hashed_name(name, original_file)
+            if name in self._prehashed:
+                # Already content-addressed by a build tool: keep its own name
+                # instead of appending a second hash.
+                hashed_name = self.clean_name(name)
+            else:
+                hashed_name = self.hashed_name(name, original_file)
             hashed_file_exists = self.exists(hashed_name)
             processed = False
 
@@ -1195,6 +1234,7 @@ class EnhancedManifestStaticFilesStorage(
         ignore_errors=None,
         use_lexer=None,
         sourcemap_strict=None,
+        prehashed=None,
         *args,
         **kwargs,
     ):
@@ -1217,6 +1257,12 @@ class EnhancedManifestStaticFilesStorage(
             self.use_lexer = use_lexer
         if sourcemap_strict is not None:
             self.sourcemap_strict = sourcemap_strict
+        if prehashed is not None:
+            if not (callable(prehashed) or isinstance(prehashed, str)):
+                raise ImproperlyConfigured(
+                    "prehashed must be a callable or a dotted path to one"
+                )
+            self.prehashed = prehashed
         super().__init__(location, base_url, *args, **kwargs)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-manifeststaticfiles-enhanced"
-version = "0.9.1"
+version = "0.10.0"
 description = "Enhanced ManifestStaticFilesStorage for Django"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/tests/staticfiles_tests/storage.py
+++ b/tests/staticfiles_tests/storage.py
@@ -1,4 +1,5 @@
 import os
+import re
 from datetime import datetime, timedelta, timezone
 
 from django.conf import settings
@@ -115,3 +116,29 @@ class JSModuleImportAggregationManifestStorageLexer(EnhancedManifestStaticFilesS
 
 class CSSLexerStorage(EnhancedManifestStaticFilesStorage):
     use_lexer = True
+
+
+def always_prehashed(name):
+    """Module-level callable used to exercise the dotted-path `prehashed` option."""
+    return True
+
+
+# Matches bundler-style content-hashed names such as "app.0abcdef0.js".
+_PREHASHED_RE = re.compile(r"\.[0-9a-f]{8}\.[a-z0-9]+$")
+
+
+class PrehashedStorage(EnhancedManifestStaticFilesStorage):
+    """
+    Treat files under dist/ that already carry a bundler-style content hash as
+    pre-hashed, so they are passed through untouched.
+    """
+
+    support_js_module_import_aggregation = True
+
+    def is_prehashed(self, name):
+        name = name.replace(os.sep, "/")
+        return name.startswith("dist/") and bool(_PREHASHED_RE.search(name))
+
+
+class PrehashedNoKeepStorage(PrehashedStorage):
+    keep_original_files = False

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -2162,3 +2162,102 @@ class TestTestingManifestStaticFilesStorage(CollectionTestCase):
         self.assertStaticRaises(
             ValueError, "does/not/exist.png", "/static/does/not/exist.png"
         )
+
+
+class _PrehashedTestMixin:
+    """
+    Builds a bundler-style dist/ tree and collects it. The storage backend
+    (set by the concrete subclass) treats files with a bundler hash as
+    pre-hashed and passes them through untouched.
+
+      dist/app.0abcdef0.js     -> pre-hashed, imports the pre-hashed chunk
+      dist/chunk.1234abcd.js    -> pre-hashed
+      dist/loader.js            -> NOT pre-hashed, imports the pre-hashed entry
+    """
+
+    run_collectstatic_in_setUp = False
+
+    def setUp(self):
+        super().setUp()
+        self.dist_root = tempfile.mkdtemp()
+        dist = os.path.join(self.dist_root, "dist")
+        os.makedirs(dist)
+        with open(os.path.join(dist, "chunk.1234abcd.js"), "w") as f:
+            f.write("export const greeting = 'hi';\n")
+        with open(os.path.join(dist, "app.0abcdef0.js"), "w") as f:
+            f.write(
+                "import { greeting } from './chunk.1234abcd.js';\n"
+                "console.log(greeting);\n"
+            )
+        with open(os.path.join(dist, "loader.js"), "w") as f:
+            f.write("import './app.0abcdef0.js';\n")
+        patched_settings = self.settings(
+            STATICFILES_DIRS=settings.STATICFILES_DIRS + [self.dist_root],
+        )
+        patched_settings.enable()
+        self.addCleanup(patched_settings.disable)
+        self.addCleanup(shutil.rmtree, self.dist_root)
+        self.run_collectstatic()
+
+    def test_prehashed_files_keep_their_name(self):
+        hashed_files = storage.staticfiles_storage.hashed_files
+        self.assertEqual(hashed_files["dist/app.0abcdef0.js"], "dist/app.0abcdef0.js")
+        self.assertEqual(
+            hashed_files["dist/chunk.1234abcd.js"], "dist/chunk.1234abcd.js"
+        )
+
+    def test_prehashed_internal_reference_untouched(self):
+        # The import inside the pre-hashed entry is left byte-for-byte as-is.
+        content = self._get_file(os.path.join("dist", "app.0abcdef0.js"))
+        self.assertIn("from './chunk.1234abcd.js'", content)
+
+    def test_prehashed_files_present_at_own_name(self):
+        for name in ("dist/app.0abcdef0.js", "dist/chunk.1234abcd.js"):
+            self.assertTrue(
+                os.path.exists(os.path.join(settings.STATIC_ROOT, name)),
+                "%s missing from STATIC_ROOT" % name,
+            )
+
+    def test_prehashed_files_not_double_hashed(self):
+        # No second hash was appended to the bundler's name.
+        dist = os.path.join(settings.STATIC_ROOT, "dist")
+        names = os.listdir(dist)
+        self.assertFalse(
+            [n for n in names if re.match(r"app\.0abcdef0\..+\.js$", n)],
+            "found a double-hashed copy of the pre-hashed file",
+        )
+
+    def test_reference_to_prehashed_resolves_to_own_name(self):
+        # loader.js is NOT pre-hashed, so it is processed and its import of the
+        # pre-hashed entry must resolve to the entry's own (unchanged) name.
+        hashed_files = storage.staticfiles_storage.hashed_files
+        loader_hashed = hashed_files["dist/loader.js"]
+        self.assertNotEqual(loader_hashed, "dist/loader.js")
+        content = self._get_file(loader_hashed)
+        self.assertIn("./app.0abcdef0.js", content)
+
+
+@override_settings(
+    STORAGES={
+        **settings.STORAGES,
+        STATICFILES_STORAGE_ALIAS: {
+            "BACKEND": "staticfiles_tests.storage.PrehashedStorage",
+        },
+    }
+)
+class TestCollectionPrehashedStorage(_PrehashedTestMixin, CollectionTestCase):
+    pass
+
+
+@override_settings(
+    STORAGES={
+        **settings.STORAGES,
+        STATICFILES_STORAGE_ALIAS: {
+            "BACKEND": "staticfiles_tests.storage.PrehashedNoKeepStorage",
+        },
+    }
+)
+class TestCollectionPrehashedNoKeepStorage(_PrehashedTestMixin, CollectionTestCase):
+    """Same behaviour must hold with keep_original_files=False."""
+
+    pass

--- a/tests/staticfiles_tests/test_storage_enhanced.py
+++ b/tests/staticfiles_tests/test_storage_enhanced.py
@@ -69,6 +69,33 @@ class EnhancedManifestStaticFilesStorageTest(TestCase):
             storage = EnhancedManifestStaticFilesStorage(keep_original_files=False)
             self.assertFalse(storage.keep_original_files)
 
+    def test_prehashed_default_false(self):
+        """By default no file is treated as pre-hashed."""
+        self.assertIsNone(self.storage.prehashed)
+        self.assertFalse(self.storage.is_prehashed("dist/app.0abcdef0.js"))
+
+    def test_prehashed_callable_option(self):
+        """A callable `prehashed` option drives is_prehashed."""
+        storage = EnhancedManifestStaticFilesStorage(
+            prehashed=lambda name: name.endswith(".min.js")
+        )
+        self.assertTrue(storage.is_prehashed("vendor.min.js"))
+        self.assertFalse(storage.is_prehashed("vendor.js"))
+
+    def test_prehashed_dotted_path_option(self):
+        """A dotted-path string `prehashed` option is resolved to a callable."""
+        storage = EnhancedManifestStaticFilesStorage(
+            prehashed="staticfiles_tests.storage.always_prehashed"
+        )
+        self.assertTrue(storage.is_prehashed("anything.js"))
+
+    def test_prehashed_invalid_option(self):
+        """A non-callable, non-string `prehashed` option is rejected."""
+        from django.core.exceptions import ImproperlyConfigured
+
+        with self.assertRaises(ImproperlyConfigured):
+            EnhancedManifestStaticFilesStorage(prehashed=123)
+
     def test_file_hash(self):
         """Test file hashing functionality"""
         content = ContentFile(b"test content")


### PR DESCRIPTION
Give a way for bundlers like vite to skip post processing of files they have already created a cache busting filename for.

See [django-vite issue](https://github.com/MrBin99/django-vite/issues/86)